### PR TITLE
Compatibiliza o cadastro inicial público de usuários

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -1,0 +1,28 @@
+name: Pull Request Checks
+
+on:
+  pull_request:
+  push:
+    branches:
+      - task-5
+
+jobs:
+  users-module:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+
+      - name: Validate composer files
+        run: composer validate --no-check-publish
+
+      - name: Install test dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,11 @@
 - `users` nao deve duplicar regra de vinculo, cadeia comercial ou escopo por empresa.
 - `client`, `provider` e `franchisee` podem existir no token se vierem de vinculos diretos, mas nao substituem role humana operacional.
 
+## Fluxo legado de auto-cadastro
+- O endpoint publico `POST /users/create-account` deve continuar aceitando o payload simples do front web (`name`, `email`, `password` e `confirmPassword`).
+- O retorno desse endpoint continua sendo a sessao pronta para login imediato no wrapper legado consumido pelo front web.
+- Esse contrato de resposta e uma excecao objetiva de compatibilidade externa: parsing, validacao e criacao de sessao ficam em service, e o controller deve apenas orquestrar a chamada e delegar a montagem do wrapper legado.
+
 ## Regras de autorizacao para `UserService`
 - `UserService` deve ter `securityFilter` explicito ou mecanismo equivalente com efeito comprovavel para leitura e escrita de `User`.
 - Filtro por query string, como `people=/people/{id}`, nao conta como autorizacao; o service precisa validar o escopo da pessoa autenticada sobre a entidade alvo.

--- a/README.md
+++ b/README.md
@@ -89,3 +89,31 @@ Current behavior:
 Validation:
 - focused PHPUnit coverage lives in `tests/Service/PasswordRecoveryServiceTest.php`
 - the branch workflow `Pull Request Checks` is the canonical automated evidence for this flow in review branches
+
+## Public create-account compatibility
+
+The module keeps the current public signup flow at `POST /create-account` and also accepts the legacy web route `POST /users/create-account`.
+
+### Accepted payload
+
+```json
+{
+  "name": "Maria Silva",
+  "email": "maria@example.com",
+  "password": "secret123",
+  "confirmPassword": "secret123"
+}
+```
+
+### Behaviour
+
+- both public routes create the account through the same service flow
+- a successful request returns the session payload expected by the web login flow
+- invalid public payloads return `400 Bad Request` instead of an internal server error
+- the legacy response wrapper is kept only because the existing web client still depends on it
+
+### Test coverage
+
+- `tests/Controller/CreateAccountActionTest.php`
+- `tests/Service/UserServiceCreateAccountTest.php`
+- GitHub Actions workflow: `Pull Request Checks`

--- a/composer.json
+++ b/composer.json
@@ -9,11 +9,19 @@
             "ControleOnline\\Controller\\": "src/Controller/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "ControleOnline\\Users\\Tests\\": "tests/"
+        }
+    },
     "authors": [
         {
             "name": "Controle Online",
             "email": "luiz.kim@controleonline.com"
         }
     ],
-    "require": {}
+    "require": {},
+    "require-dev": {
+        "phpunit/phpunit": "^12.1"
+    }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.1/phpunit.xsd"
+    bootstrap="tests/bootstrap.php"
+    colors="true"
+    cacheDirectory=".phpunit.cache"
+>
+    <testsuites>
+        <testsuite name="Users Module Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Controller/CreateAccountAction.php
+++ b/src/Controller/CreateAccountAction.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace ControleOnline\Controller;
+
+use ControleOnline\Service\CreateAccountResponseFactory;
+use ControleOnline\Service\UserService;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+class CreateAccountAction
+{
+    public function __construct(
+        private UserService $service,
+        private CreateAccountResponseFactory $responseFactory
+    ) {}
+
+    public function __invoke(Request $request): JsonResponse
+    {
+        try {
+            return new JsonResponse(
+                $this->responseFactory->success(
+                    $this->service->createAccountSessionFromContent(
+                        $request->getContent()
+                    )
+                )
+            );
+        } catch (\Throwable $exception) {
+            return new JsonResponse(
+                $this->responseFactory->error($exception),
+                $this->responseFactory->statusCode($exception)
+            );
+        }
+    }
+}

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -15,6 +15,7 @@ use ApiPlatform\Metadata\Delete;
 use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
 use ControleOnline\Controller\ChangeApiKeyAction;
 use ControleOnline\Controller\ChangePasswordAction;
+use ControleOnline\Controller\CreateAccountAction;
 use ControleOnline\Controller\CreateUserAction;
 use ControleOnline\Controller\SecurityController;
 use ControleOnline\Controller\UpdateUserPreferencesAction;
@@ -39,6 +40,12 @@ use Symfony\Component\Validator\Constraints as Assert;
             uriTemplate: '/users',
             controller: CreateUserAction::class,
             securityPostDenormalize: 'is_granted(\'ROLE_CLIENT\')',
+        ),
+        new Post(
+            uriTemplate: '/users/create-account',
+            controller: CreateAccountAction::class,
+            securityPostDenormalize: 'is_granted(\'PUBLIC_ACCESS\')',
+            security: 'is_granted(\'PUBLIC_ACCESS\')',
         ),
         new Put(
             security: 'is_granted(\'ROLE_CLIENT\') and object == user',
@@ -137,6 +144,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     public function setUsername(string $username): self
     {
         $this->username = $username;
+
         return $this;
     }
 
@@ -175,6 +183,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     public function generateApiKey(): string
     {
         $this->apiKey = md5($this->getUsername() . microtime());
+
         return $this->apiKey;
     }
 
@@ -186,6 +195,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     public function setHash(string $hash): self
     {
         $this->hash = $hash;
+
         return $this;
     }
 
@@ -202,12 +212,14 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     public function setOauthHash(?string $hash): self
     {
         $this->oauthHash = $hash;
+
         return $this;
     }
 
     public function setOauthUser(?string $user): self
     {
         $this->oauthUser = $user;
+
         return $this;
     }
 
@@ -219,6 +231,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     public function setPeople(People $people): self
     {
         $this->people = $people;
+
         return $this;
     }
 
@@ -242,6 +255,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     public function setLostPassword(?string $hash): self
     {
         $this->lostPassword = $hash;
+
         return $this;
     }
 

--- a/src/Service/CreateAccountResponseFactory.php
+++ b/src/Service/CreateAccountResponseFactory.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace ControleOnline\Service;
+
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+
+class CreateAccountResponseFactory
+{
+    public function success(array $session): array
+    {
+        return [
+            'response' => [
+                'data' => $session,
+                'count' => 1,
+                'error' => '',
+                'success' => true,
+            ],
+        ];
+    }
+
+    public function error(\Throwable $exception): array
+    {
+        return [
+            'response' => [
+                'data' => [],
+                'count' => 0,
+                'error' => $exception->getMessage(),
+                'success' => false,
+            ],
+        ];
+    }
+
+    public function statusCode(\Throwable $exception): int
+    {
+        if ($exception instanceof HttpExceptionInterface) {
+            return $exception->getStatusCode();
+        }
+
+        if ($exception->getCode() >= 300 && $exception->getCode() < 500) {
+            return 400;
+        }
+
+        return 500;
+    }
+}

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -9,8 +9,8 @@ use ControleOnline\Entity\Timezone;
 use ControleOnline\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
 use Exception;
-use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
 class UserService
 {
@@ -31,6 +31,7 @@ class UserService
 
         $this->manager->persist($user);
         $this->manager->flush();
+
         return $user;
     }
 
@@ -54,6 +55,7 @@ class UserService
 
         $this->manager->persist($user);
         $this->manager->flush();
+
         return $user;
     }
 
@@ -111,6 +113,45 @@ class UserService
         ];
     }
 
+    public function createAccountSessionFromContent(?string $content): array
+    {
+        return $this->getUserSession(
+            $this->createAccountUserFromPayload(
+                $this->decodeStrictPayload($content)
+            )
+        );
+    }
+
+    public function createAccountUserFromPayload(array $payload): User
+    {
+        foreach (['name', 'email', 'password'] as $field) {
+            if (!isset($payload[$field]) || trim((string) $payload[$field]) === '') {
+                throw new BadRequestHttpException('name, email and password are required');
+            }
+        }
+
+        if (
+            isset($payload['confirmPassword']) &&
+            (string) $payload['confirmPassword'] !== (string) $payload['password']
+        ) {
+            throw new BadRequestHttpException('password confirmation does not match');
+        }
+
+        [$firstName, $lastName] = $this->splitName((string) $payload['name']);
+
+        $people = $this->discoveryPeople(
+            (string) $payload['email'],
+            $firstName,
+            $lastName
+        );
+
+        return $this->createUser(
+            $people,
+            (string) $payload['email'],
+            (string) $payload['password']
+        );
+    }
+
     private function getUserRealName(People $people): string
     {
         $realName = 'John Doe';
@@ -155,6 +196,7 @@ class UserService
 
         $this->manager->persist($people);
         $this->manager->flush();
+
         return $people;
     }
 
@@ -180,6 +222,7 @@ class UserService
 
         $this->manager->persist($user);
         $this->manager->flush();
+
         return $user;
     }
 
@@ -286,6 +329,7 @@ class UserService
     public function getCompanyId(User $user)
     {
         $company = $this->getCompany($user);
+
         return $company ? $company->getId() : null;
     }
 
@@ -344,6 +388,34 @@ class UserService
         $decoded = json_decode($content, true);
 
         return is_array($decoded) ? $decoded : [];
+    }
+
+    private function decodeStrictPayload(?string $content): array
+    {
+        if (!is_string($content) || trim($content) === '') {
+            return [];
+        }
+
+        $decoded = json_decode($content, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new BadRequestHttpException('invalid json payload');
+        }
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    private function splitName(string $name): array
+    {
+        $name = trim((string) preg_replace('/\s+/', ' ', $name));
+
+        if ($name === '') {
+            return ['', ''];
+        }
+
+        $parts = explode(' ', $name, 2);
+
+        return [$parts[0], $parts[1] ?? ''];
     }
 
     private function extractTimezoneId(mixed $value): ?int

--- a/tests/Controller/CreateAccountActionTest.php
+++ b/tests/Controller/CreateAccountActionTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace ControleOnline\Users\Tests\Controller;
+
+use ControleOnline\Controller\CreateAccountAction;
+use ControleOnline\Service\CreateAccountResponseFactory;
+use ControleOnline\Service\UserService;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+class CreateAccountActionTest extends TestCase
+{
+    public function testReturnsValidationErrorWithoutMaskingItAsServerError(): void
+    {
+        $payload = json_encode([
+            'name' => 'Maria Silva',
+            'email' => 'maria@example.com',
+            'password' => 'secret',
+            'confirmPassword' => 'different',
+        ], JSON_THROW_ON_ERROR);
+
+        $service = $this->createMock(UserService::class);
+        $service
+            ->expects(self::once())
+            ->method('createAccountSessionFromContent')
+            ->with($payload)
+            ->willThrowException(new BadRequestHttpException('password confirmation does not match'));
+
+        $action = new CreateAccountAction($service, new CreateAccountResponseFactory());
+        $response = $action(new Request(content: $payload));
+
+        self::assertSame(400, $response->getStatusCode());
+        self::assertSame([
+            'response' => [
+                'data' => [],
+                'count' => 0,
+                'error' => 'password confirmation does not match',
+                'success' => false,
+            ],
+        ], json_decode((string) $response->getContent(), true));
+    }
+
+    public function testReturnsStructuredSessionPayloadForSuccessfulSignup(): void
+    {
+        $payload = json_encode([
+            'name' => 'Maria Silva',
+            'email' => 'maria@example.com',
+            'password' => 'secret',
+            'confirmPassword' => 'secret',
+        ], JSON_THROW_ON_ERROR);
+
+        $service = $this->createMock(UserService::class);
+        $service
+            ->expects(self::once())
+            ->method('createAccountSessionFromContent')
+            ->with($payload)
+            ->willReturn([
+                'id' => 15,
+                'username' => 'maria@example.com',
+                'api_key' => 'abc123',
+            ]);
+
+        $action = new CreateAccountAction($service, new CreateAccountResponseFactory());
+        $response = $action(new Request(content: $payload));
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame([
+            'response' => [
+                'data' => [
+                    'id' => 15,
+                    'username' => 'maria@example.com',
+                    'api_key' => 'abc123',
+                ],
+                'count' => 1,
+                'error' => '',
+                'success' => true,
+            ],
+        ], json_decode((string) $response->getContent(), true));
+    }
+}

--- a/tests/Service/UserServiceCreateAccountTest.php
+++ b/tests/Service/UserServiceCreateAccountTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace ControleOnline\Users\Tests\Service;
+
+use ControleOnline\Entity\User;
+use ControleOnline\Service\FileService;
+use ControleOnline\Service\UserService;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+class UserServiceCreateAccountTest extends TestCase
+{
+    public function testRequiresNameEmailAndPassword(): void
+    {
+        $service = $this->createService();
+
+        $this->expectException(BadRequestHttpException::class);
+        $this->expectExceptionMessage('name, email and password are required');
+
+        $service->createAccountSessionFromContent(json_encode([
+            'email' => 'maria@example.com',
+            'password' => 'secret',
+        ], JSON_THROW_ON_ERROR));
+    }
+
+    public function testRejectsDifferentPasswordConfirmation(): void
+    {
+        $service = $this->createService();
+
+        $this->expectException(BadRequestHttpException::class);
+        $this->expectExceptionMessage('password confirmation does not match');
+
+        $service->createAccountSessionFromContent(json_encode([
+            'name' => 'Maria Silva',
+            'email' => 'maria@example.com',
+            'password' => 'secret',
+            'confirmPassword' => 'different',
+        ], JSON_THROW_ON_ERROR));
+    }
+
+    public function testBuildsSessionUsingSplitNameAndUserCreationFlow(): void
+    {
+        $people = new \stdClass();
+        $user = $this->createMock(User::class);
+
+        $service = $this->createPartialMockedService();
+        $service
+            ->expects(self::once())
+            ->method('discoveryPeople')
+            ->with('maria@example.com', 'Maria', 'Silva')
+            ->willReturn($people);
+        $service
+            ->expects(self::once())
+            ->method('createUser')
+            ->with($people, 'maria@example.com', 'secret')
+            ->willReturn($user);
+        $service
+            ->expects(self::once())
+            ->method('getUserSession')
+            ->with($user)
+            ->willReturn([
+                'id' => 15,
+                'username' => 'maria@example.com',
+                'api_key' => 'abc123',
+            ]);
+
+        self::assertSame([
+            'id' => 15,
+            'username' => 'maria@example.com',
+            'api_key' => 'abc123',
+        ], $service->createAccountSessionFromContent(json_encode([
+            'name' => 'Maria Silva',
+            'email' => 'maria@example.com',
+            'password' => 'secret',
+            'confirmPassword' => 'secret',
+        ], JSON_THROW_ON_ERROR)));
+    }
+
+    private function createService(): UserService
+    {
+        return new UserService(
+            $this->createMock(EntityManagerInterface::class),
+            $this->createMock(UserPasswordHasherInterface::class),
+            $this->createMock(FileService::class)
+        );
+    }
+
+    private function createPartialMockedService(): UserService
+    {
+        return $this->getMockBuilder(UserService::class)
+            ->setConstructorArgs([
+                $this->createMock(EntityManagerInterface::class),
+                $this->createMock(UserPasswordHasherInterface::class),
+                $this->createMock(FileService::class),
+            ])
+            ->onlyMethods(['discoveryPeople', 'createUser', 'getUserSession'])
+            ->getMock();
+    }
+}

--- a/tests/Service/UserServiceCreateAccountTest.php
+++ b/tests/Service/UserServiceCreateAccountTest.php
@@ -2,6 +2,7 @@
 
 namespace ControleOnline\Users\Tests\Service;
 
+use ControleOnline\Entity\People;
 use ControleOnline\Entity\User;
 use ControleOnline\Service\FileService;
 use ControleOnline\Service\UserService;
@@ -42,7 +43,7 @@ class UserServiceCreateAccountTest extends TestCase
 
     public function testBuildsSessionUsingSplitNameAndUserCreationFlow(): void
     {
-        $people = new \stdClass();
+        $people = new People();
         $user = $this->createMock(User::class);
 
         $service = $this->createPartialMockedService();

--- a/tests/Service/UserServiceTest.php
+++ b/tests/Service/UserServiceTest.php
@@ -2,16 +2,9 @@
 
 namespace ControleOnline\Tests\Service;
 
-require_once dirname(__DIR__, 2) . '/src/Entity/User.php';
-require_once dirname(__DIR__, 3) . '/common/src/Entity/Timezone.php';
-require_once dirname(__DIR__, 2) . '/src/Service/UserService.php';
-require_once dirname(__DIR__, 3) . '/common/src/Service/FileService.php';
-require_once dirname(__DIR__, 3) . '/people/src/Service/PeopleRoleService.php';
-
 use ControleOnline\Entity\Timezone;
 use ControleOnline\Entity\User;
 use ControleOnline\Service\FileService;
-use ControleOnline\Service\PeopleRoleService;
 use ControleOnline\Service\UserService;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
@@ -75,7 +68,6 @@ class UserServiceTest extends TestCase
             $manager,
             $this->createMock(UserPasswordHasherInterface::class),
             $this->createMock(FileService::class),
-            $this->createMock(PeopleRoleService::class),
         );
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,8 +8,66 @@ $autoloadPaths = [
 foreach ($autoloadPaths as $autoloadPath) {
     if (is_file($autoloadPath)) {
         require_once $autoloadPath;
-        return;
+        break;
     }
 }
 
-throw new RuntimeException('Composer autoload.php not found for users module tests.');
+if (!interface_exists('Symfony\\Component\\Security\\Core\\User\\UserInterface')) {
+    eval('namespace Symfony\\Component\\Security\\Core\\User; interface UserInterface { public function getRoles(): array; public function eraseCredentials(): void; public function getUserIdentifier(): string; }');
+}
+
+if (!interface_exists('Symfony\\Component\\Security\\Core\\User\\PasswordAuthenticatedUserInterface')) {
+    eval('namespace Symfony\\Component\\Security\\Core\\User; interface PasswordAuthenticatedUserInterface { public function getPassword(): ?string; }');
+}
+
+if (!interface_exists('Symfony\\Component\\HttpKernel\\Exception\\HttpExceptionInterface')) {
+    eval('namespace Symfony\\Component\\HttpKernel\\Exception; interface HttpExceptionInterface extends \\Throwable { public function getStatusCode(): int; }');
+}
+
+if (!class_exists('Symfony\\Component\\HttpKernel\\Exception\\BadRequestHttpException')) {
+    eval('namespace Symfony\\Component\\HttpKernel\\Exception; class BadRequestHttpException extends \\RuntimeException implements HttpExceptionInterface { public function __construct(string $message = "", int $code = 0, ?\\Throwable $previous = null) { parent::__construct($message, $code, $previous); } public function getStatusCode(): int { return 400; } }');
+}
+
+if (!class_exists('Symfony\\Component\\HttpFoundation\\Request')) {
+    eval('namespace Symfony\\Component\\HttpFoundation; class Request { public function __construct(private ?string $content = null) {} public function getContent(): string { return $this->content ?? ""; } public function get(string $key): mixed { return null; } }');
+}
+
+if (!class_exists('Symfony\\Component\\HttpFoundation\\JsonResponse')) {
+    eval('namespace Symfony\\Component\\HttpFoundation; class JsonResponse { public function __construct(private mixed $data = null, private int $status = 200) {} public function getStatusCode(): int { return $this->status; } public function getContent(): string { return json_encode($this->data, JSON_THROW_ON_ERROR); } }');
+}
+
+if (!interface_exists('Symfony\\Component\\PasswordHasher\\Hasher\\UserPasswordHasherInterface')) {
+    eval('namespace Symfony\\Component\\PasswordHasher\\Hasher; interface UserPasswordHasherInterface { public function hashPassword(object $user, string $plainPassword): string; }');
+}
+
+if (!interface_exists('Doctrine\\ORM\\EntityManagerInterface')) {
+    eval('namespace Doctrine\\ORM; interface EntityManagerInterface { public function getRepository(string $className); public function persist(object $object): void; public function flush(): void; public function getConnection(); }');
+}
+
+if (!class_exists('Doctrine\\ORM\\EntityRepository')) {
+    eval('namespace Doctrine\\ORM; class EntityRepository {}');
+}
+
+if (!class_exists('ControleOnline\\Service\\FileService')) {
+    eval('namespace ControleOnline\\Service; class FileService { public function getFileUrl(object $entity): string { return ""; } }');
+}
+
+if (!class_exists('ControleOnline\\Entity\\Timezone')) {
+    eval('namespace ControleOnline\\Entity; class Timezone { private ?int $id = null; private string $name = ""; public function setName(string $name): self { $this->name = $name; return $this; } public function getName(): string { return $this->name; } public function getId(): ?int { return $this->id; } }');
+}
+
+if (!class_exists('ControleOnline\\Entity\\Language')) {
+    eval('namespace ControleOnline\\Entity; class Language { public function getLanguage(): string { return "pt-BR"; } }');
+}
+
+if (!class_exists('ControleOnline\\Entity\\People')) {
+    eval('namespace ControleOnline\\Entity; class People { private ?Timezone $timezone = null; public function getId(): ?int { return 1; } public function getName(): string { return ""; } public function getAlias(): string { return ""; } public function getLanguage(): ?Language { return null; } public function getEnabled(): bool { return true; } public function getPeopleType(): string { return "F"; } public function getLink() { return new class { public function first() { return false; } }; } public function getEmail() { return new class { public function count(): int { return 0; } public function first() { return null; } }; } public function getPhone() { return new class { public function count(): int { return 0; } public function first() { return null; } }; } }');
+}
+
+if (!class_exists('ControleOnline\\Entity\\Email')) {
+    eval('namespace ControleOnline\\Entity; class Email { public function setEmail(string $email): void {} public function setPeople(People $people): void {} public function getPeople(): ?People { return null; } public function getEmail(): string { return ""; } }');
+}
+
+if (!class_exists('ControleOnline\\Entity\\User')) {
+    eval('namespace ControleOnline\\Entity; class User { private ?Timezone $timezone = null; public function setTimezone(?Timezone $timezone): self { $this->timezone = $timezone; return $this; } public function getTimezone(): ?Timezone { return $this->timezone; } }');
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -45,7 +45,7 @@ if (!interface_exists('Doctrine\\ORM\\EntityManagerInterface')) {
 }
 
 if (!class_exists('Doctrine\\ORM\\EntityRepository')) {
-    eval('namespace Doctrine\\ORM; class EntityRepository {}');
+    eval('namespace Doctrine\\ORM; class EntityRepository { public function find(mixed $id): mixed { return null; } public function findOneBy(array $criteria): mixed { return null; } }');
 }
 
 if (!class_exists('ControleOnline\\Service\\FileService')) {
@@ -61,7 +61,7 @@ if (!class_exists('ControleOnline\\Entity\\Language')) {
 }
 
 if (!class_exists('ControleOnline\\Entity\\People')) {
-    eval('namespace ControleOnline\\Entity; class People { private ?Timezone $timezone = null; public function getId(): ?int { return 1; } public function getName(): string { return ""; } public function getAlias(): string { return ""; } public function getLanguage(): ?Language { return null; } public function getEnabled(): bool { return true; } public function getPeopleType(): string { return "F"; } public function getLink() { return new class { public function first() { return false; } }; } public function getEmail() { return new class { public function count(): int { return 0; } public function first() { return null; } }; } public function getPhone() { return new class { public function count(): int { return 0; } public function first() { return null; } }; } }');
+    eval('namespace ControleOnline\\Entity; class People { public function getId(): ?int { return 1; } public function getName(): string { return ""; } public function getAlias(): string { return ""; } public function getLanguage(): ?Language { return null; } public function getEnabled(): bool { return true; } public function getPeopleType(): string { return "F"; } public function getLink() { return new class { public function first() { return false; } }; } public function getEmail() { return new class { public function count(): int { return 0; } public function first() { return null; } }; } public function getPhone() { return new class { public function count(): int { return 0; } public function first() { return null; } }; } }');
 }
 
 if (!class_exists('ControleOnline\\Entity\\Email')) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,15 @@
+<?php
+
+$autoloadPaths = [
+    __DIR__ . '/../vendor/autoload.php',
+    __DIR__ . '/../../../../vendor/autoload.php',
+];
+
+foreach ($autoloadPaths as $autoloadPath) {
+    if (is_file($autoloadPath)) {
+        require_once $autoloadPath;
+        return;
+    }
+}
+
+throw new RuntimeException('Composer autoload.php not found for users module tests.');


### PR DESCRIPTION
Atende a issue `ControleOnline/api-community#5`.

## O que mudou
- restaura o endpoint público `POST /users/create-account` no módulo `users`
- aceita o payload simples usado pelo front web (`name`, `email`, `password`, `confirmPassword`)
- retorna a sessão pronta para login imediato, preservando o contrato esperado pelo cliente
- registra a regra no `AGENTS.md` do módulo

## Contexto
O front web ainda chama a rota legada `users/create-account`, mas a versão atual do backend só mantinha o fluxo mais novo em `/create-account`. Isso quebrava o cadastro inicial de usuários no cliente web.

## Validação
- inspeção do diff e cruzamento com o payload real do front em `ui-login`
- não foi possível rodar testes locais nesta sessão porque o ambiente não possui runtime `php`
