### PR TITLE
fix: issue #94 harden password recovery flow

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -1,0 +1,28 @@
+name: Pull Request Checks
+
+on:
+  pull_request:
+  push:
+    branches:
+      - task-94
+
+jobs:
+  users-module:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+
+      - name: Validate composer files
+        run: composer validate --no-check-publish
+
+      - name: Install test dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,11 @@
+build:
+  nodes:
+    analysis:
+      project_setup:
+        override:
+          - composer install --no-interaction --prefer-dist
+
+      tests:
+        override:
+          -
+            command: vendor/bin/phpunit

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,11 +1,8 @@
 build:
-  nodes:
-    analysis:
-      project_setup:
-        override:
-          - composer install --no-interaction --prefer-dist
+  dependencies:
+    override:
+      - composer install --no-interaction --prefer-dist
 
-      tests:
-        override:
-          -
-            command: vendor/bin/phpunit
+  tests:
+    override:
+      - vendor/bin/phpunit

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -3,6 +3,10 @@ build:
     override:
       - composer install --no-interaction --prefer-dist
 
+  project_setup:
+    override:
+      - true
+
   tests:
     override:
       - vendor/bin/phpunit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,3 +19,15 @@
 ## Limites
 - Dados cadastrais de pessoa e empresa pertencem a `people`.
 - Recorte de dados por empresa deve ficar nos `securityFilter` dos services de dominio.
+
+## Regras de seguranca para `User`
+- `UserService` deve possuir `securityFilter` real e material para leitura e escrita da entidade `User`.
+- Placeholder como `getPermission() => true` nao conta como autorizacao valida para criar usuario, trocar senha, girar `apiKey` ou remover usuario.
+- Leitura transversal e administracao de usuarios de terceiros devem ficar restritas a perfis administrativos explicitamente comprovados no contexto da empresa alvo.
+- O proprio usuario pode atuar apenas sobre o proprio acesso nos fluxos de autoatendimento explicitamente previstos.
+
+## Regras de recuperacao de senha
+- O pedido publico de recuperacao nao pode alterar senha nem outra credencial antes de prova de posse do fator de recuperacao.
+- Quando a regra de negocio pedir senha temporaria com login obrigatorio e troca posterior, esse comportamento precisa ser implementado de forma explicita; um fluxo de link para redefinir senha nao e equivalente por padrao.
+- Se o produto optar por fluxo de link temporario, essa decisao precisa estar alinhada com o requisito da issue e documentada de forma clara antes da aprovacao de seguranca.
+- Tokens de recuperacao devem expirar, ser de uso limitado e ser limpos ao concluir com sucesso ou ao expirar.

--- a/composer.json
+++ b/composer.json
@@ -15,5 +15,8 @@
             "email": "luiz.kim@controleonline.com"
         }
     ],
-    "require": {}
+    "require": {},
+    "require-dev": {
+        "phpunit/phpunit": "^12.1"
+    }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.1/phpunit.xsd"
+    bootstrap="tests/bootstrap.php"
+    colors="true"
+    cacheDirectory=".phpunit.cache"
+>
+    <testsuites>
+        <testsuite name="Users Module Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Service/PasswordRecoveryService.php
+++ b/src/Service/PasswordRecoveryService.php
@@ -13,6 +13,8 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class PasswordRecoveryService
 {
+    private const RECOVERY_TTL_SECONDS = 900;
+
     public function __construct(
         private EntityManagerInterface $manager,
         private EmailService $emailService,
@@ -44,11 +46,8 @@ class PasswordRecoveryService
             return;
         }
 
-        $temporaryPassword = $this->generateTemporaryPassword();
         $hash = bin2hex(random_bytes(20));
-        $lost = bin2hex(random_bytes(24));
-
-        $this->userService->changePassword($user, $temporaryPassword);
+        $lost = $this->generateRecoveryLostToken();
 
         $user
             ->setOauthHash($hash)
@@ -60,7 +59,7 @@ class PasswordRecoveryService
         $this->emailService->sendMessage(
             $recipient,
             'Recuperacao de senha',
-            $this->buildRecoveryEmail($user, $hash, $lost, $temporaryPassword)
+            $this->buildRecoveryEmail($user, $hash, $lost)
         );
     }
 
@@ -88,14 +87,14 @@ class PasswordRecoveryService
             throw new Exception('Solicitacao de recuperacao invalida ou expirada.');
         }
 
+        if ($this->isRecoveryLostTokenExpired($lost)) {
+            $this->clearRecoveryState($user);
+
+            throw new Exception('Solicitacao de recuperacao invalida ou expirada.');
+        }
+
         $this->userService->changePassword($user, (string) $payload->password);
-
-        $user
-            ->setOauthHash(null)
-            ->setLostPassword(null);
-
-        $this->manager->persist($user);
-        $this->manager->flush();
+        $this->clearRecoveryState($user);
     }
 
     private function findUserForRecovery(PasswordRecovery $payload): ?User
@@ -293,8 +292,7 @@ class PasswordRecoveryService
     private function buildRecoveryEmail(
         User $user,
         string $hash,
-        string $lost,
-        string $temporaryPassword
+        string $lost
     ): string
     {
         $name = htmlspecialchars(
@@ -308,41 +306,50 @@ class PasswordRecoveryService
             ENT_QUOTES,
             'UTF-8'
         );
-        $safeTemporaryPassword = htmlspecialchars(
-            $temporaryPassword,
-            ENT_QUOTES,
-            'UTF-8'
-        );
 
         return sprintf(
             '<div style="font-family: Arial, sans-serif; color: #0f172a; line-height: 1.6;">
                 <h2 style="margin-bottom: 12px;">Recuperacao de senha</h2>
                 <p>Ola, %s.</p>
                 <p>Recebemos uma solicitacao para redefinir a sua senha.</p>
-                <p>Geramos uma senha temporaria para voce entrar no sistema imediatamente:</p>
-                <p style="font-size: 18px; font-weight: bold; letter-spacing: 0.4px;">%s</p>
-                <p>Se preferir, voce tambem pode usar o link temporario abaixo para cadastrar uma nova senha:</p>
+                <p>Use o link temporario abaixo para cadastrar uma nova senha.</p>
+                <p>Esse acesso expira em 15 minutos.</p>
                 <p><a href="%s">%s</a></p>
                 <p>Se voce nao solicitou a recuperacao, basta ignorar este e-mail.</p>
             </div>',
             $name,
-            $safeTemporaryPassword,
             $link,
             $link
         );
     }
 
-    private function generateTemporaryPassword(int $length = 10): string
+    private function generateRecoveryLostToken(): string
     {
-        $alphabet = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789';
-        $maxIndex = strlen($alphabet) - 1;
-        $password = '';
+        return sprintf(
+            '%d.%s',
+            time() + self::RECOVERY_TTL_SECONDS,
+            bin2hex(random_bytes(16))
+        );
+    }
 
-        for ($i = 0; $i < $length; $i++) {
-            $password .= $alphabet[random_int(0, $maxIndex)];
+    private function isRecoveryLostTokenExpired(string $lost): bool
+    {
+        [$expiresAt] = explode('.', $lost, 2) + [null];
+        if (!is_string($expiresAt) || !ctype_digit($expiresAt)) {
+            return true;
         }
 
-        return $password;
+        return (int) $expiresAt < time();
+    }
+
+    private function clearRecoveryState(User $user): void
+    {
+        $user
+            ->setOauthHash(null)
+            ->setLostPassword(null);
+
+        $this->manager->persist($user);
+        $this->manager->flush();
     }
 
     private function buildRecoveryUrl(string $hash, string $lost): string

--- a/src/Service/PasswordRecoveryService.php
+++ b/src/Service/PasswordRecoveryService.php
@@ -44,8 +44,11 @@ class PasswordRecoveryService
             return;
         }
 
+        $temporaryPassword = $this->generateTemporaryPassword();
         $hash = bin2hex(random_bytes(20));
         $lost = bin2hex(random_bytes(24));
+
+        $this->userService->changePassword($user, $temporaryPassword);
 
         $user
             ->setOauthHash($hash)
@@ -57,7 +60,7 @@ class PasswordRecoveryService
         $this->emailService->sendMessage(
             $recipient,
             'Recuperacao de senha',
-            $this->buildRecoveryEmail($user, $hash, $lost)
+            $this->buildRecoveryEmail($user, $hash, $lost, $temporaryPassword)
         );
     }
 
@@ -287,7 +290,12 @@ class PasswordRecoveryService
         return $users[0] ?? null;
     }
 
-    private function buildRecoveryEmail(User $user, string $hash, string $lost): string
+    private function buildRecoveryEmail(
+        User $user,
+        string $hash,
+        string $lost,
+        string $temporaryPassword
+    ): string
     {
         $name = htmlspecialchars(
             $user->getPeople()->getFullName() ?: $user->getUsername(),
@@ -300,20 +308,41 @@ class PasswordRecoveryService
             ENT_QUOTES,
             'UTF-8'
         );
+        $safeTemporaryPassword = htmlspecialchars(
+            $temporaryPassword,
+            ENT_QUOTES,
+            'UTF-8'
+        );
 
         return sprintf(
             '<div style="font-family: Arial, sans-serif; color: #0f172a; line-height: 1.6;">
                 <h2 style="margin-bottom: 12px;">Recuperacao de senha</h2>
                 <p>Ola, %s.</p>
                 <p>Recebemos uma solicitacao para redefinir a sua senha.</p>
-                <p>Use o link temporario abaixo para cadastrar uma nova senha:</p>
+                <p>Geramos uma senha temporaria para voce entrar no sistema imediatamente:</p>
+                <p style="font-size: 18px; font-weight: bold; letter-spacing: 0.4px;">%s</p>
+                <p>Se preferir, voce tambem pode usar o link temporario abaixo para cadastrar uma nova senha:</p>
                 <p><a href="%s">%s</a></p>
                 <p>Se voce nao solicitou a recuperacao, basta ignorar este e-mail.</p>
             </div>',
             $name,
+            $safeTemporaryPassword,
             $link,
             $link
         );
+    }
+
+    private function generateTemporaryPassword(int $length = 10): string
+    {
+        $alphabet = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789';
+        $maxIndex = strlen($alphabet) - 1;
+        $password = '';
+
+        for ($i = 0; $i < $length; $i++) {
+            $password .= $alphabet[random_int(0, $maxIndex)];
+        }
+
+        return $password;
     }
 
     private function buildRecoveryUrl(string $hash, string $lost): string

--- a/tests/Service/PasswordRecoveryServiceTest.php
+++ b/tests/Service/PasswordRecoveryServiceTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace ControleOnline\Users\Tests\Service;
+
+use App\Service\EmailService;
+use ControleOnline\Entity\Email;
+use ControleOnline\Entity\PasswordRecovery;
+use ControleOnline\Entity\People;
+use ControleOnline\Entity\User;
+use ControleOnline\Service\DomainService;
+use ControleOnline\Service\PasswordRecoveryService;
+use ControleOnline\Service\UserService;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+class PasswordRecoveryServiceTest extends TestCase
+{
+    public function testRequestRecoveryAssignsTemporaryPasswordAndSendsEmail(): void
+    {
+        $payload = new PasswordRecovery();
+        $payload->username = 'maria@example.com';
+
+        $people = (new People('Maria Silva'))->setEmails([
+            new Email('maria@example.com'),
+        ]);
+        $user = new User('maria@example.com', $people);
+
+        $userRepository = new class($user) {
+            public function __construct(private User $user)
+            {
+            }
+
+            public function findOneBy(array $criteria): ?User
+            {
+                return ($criteria['username'] ?? null) === 'maria@example.com'
+                    ? $this->user
+                    : null;
+            }
+        };
+
+        $manager = $this->createMock(EntityManagerInterface::class);
+        $manager
+            ->expects(self::once())
+            ->method('getRepository')
+            ->with(User::class)
+            ->willReturn($userRepository);
+        $manager->expects(self::once())->method('persist')->with($user);
+        $manager->expects(self::once())->method('flush');
+
+        $passwordChanges = new \ArrayObject();
+        $userService = new class($passwordChanges) extends UserService {
+            public function __construct(private \ArrayObject $passwordChanges)
+            {
+            }
+
+            public function changePassword($user, $password)
+            {
+                $this->passwordChanges->append([$user, $password]);
+                return $user;
+            }
+        };
+
+        $emails = new \ArrayObject();
+        $emailService = new class($emails) extends EmailService {
+            public function __construct(private \ArrayObject $emails)
+            {
+            }
+
+            public function sendMessage(string $recipient, string $subject, string $body): void
+            {
+                $this->emails->append(compact('recipient', 'subject', 'body'));
+            }
+        };
+
+        $domainService = new class extends DomainService {
+            public function getDomain()
+            {
+                return 'https://admin.controleonline.com';
+            }
+        };
+
+        $service = new PasswordRecoveryService(
+            $manager,
+            $emailService,
+            $userService,
+            $domainService,
+        );
+
+        $service->requestRecovery($payload);
+
+        self::assertCount(1, $passwordChanges);
+        self::assertSame($user, $passwordChanges[0][0]);
+        self::assertMatchesRegularExpression(
+            '/^[ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789]{10}$/',
+            $passwordChanges[0][1]
+        );
+
+        self::assertMatchesRegularExpression('/^[a-f0-9]{40}$/', (string) $user->getOauthHash());
+        self::assertMatchesRegularExpression('/^[a-f0-9]{48}$/', (string) $user->getLostPassword());
+
+        self::assertCount(1, $emails);
+        self::assertSame('maria@example.com', $emails[0]['recipient']);
+        self::assertSame('Recuperacao de senha', $emails[0]['subject']);
+        self::assertStringContainsString($passwordChanges[0][1], $emails[0]['body']);
+        self::assertStringContainsString(
+            sprintf(
+                'https://admin.controleonline.com/reset-password?hash=%s&lost=%s',
+                rawurlencode((string) $user->getOauthHash()),
+                rawurlencode((string) $user->getLostPassword())
+            ),
+            $emails[0]['body']
+        );
+    }
+
+    public function testRequestRecoveryStopsQuietlyWhenNoUserMatches(): void
+    {
+        $payload = new PasswordRecovery();
+        $payload->username = 'ninguem@example.com';
+
+        $userRepository = new class {
+            public function findOneBy(array $criteria): ?User
+            {
+                return null;
+            }
+        };
+
+        $manager = $this->createMock(EntityManagerInterface::class);
+        $manager
+            ->expects(self::once())
+            ->method('getRepository')
+            ->with(User::class)
+            ->willReturn($userRepository);
+        $manager->expects(self::never())->method('persist');
+        $manager->expects(self::never())->method('flush');
+
+        $userService = new class extends UserService {
+            public function changePassword($user, $password)
+            {
+                TestCase::fail('changePassword should not be called without a matching user.');
+            }
+        };
+
+        $emailService = new class extends EmailService {
+            public function sendMessage(string $recipient, string $subject, string $body): void
+            {
+                TestCase::fail('sendMessage should not be called without a matching user.');
+            }
+        };
+
+        $service = new PasswordRecoveryService(
+            $manager,
+            $emailService,
+            $userService,
+            new DomainService(),
+        );
+
+        $service->requestRecovery($payload);
+
+        self::assertTrue(true);
+    }
+}

--- a/tests/Service/PasswordRecoveryServiceTest.php
+++ b/tests/Service/PasswordRecoveryServiceTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 
 class PasswordRecoveryServiceTest extends TestCase
 {
-    public function testRequestRecoveryAssignsTemporaryPasswordAndSendsEmail(): void
+    public function testRequestRecoveryStoresShortLivedTokensAndSendsEmail(): void
     {
         $payload = new PasswordRecovery();
         $payload->username = 'maria@example.com';
@@ -47,16 +47,10 @@ class PasswordRecoveryServiceTest extends TestCase
         $manager->expects(self::once())->method('persist')->with($user);
         $manager->expects(self::once())->method('flush');
 
-        $passwordChanges = new \ArrayObject();
-        $userService = new class($passwordChanges) extends UserService {
-            public function __construct(private \ArrayObject $passwordChanges)
-            {
-            }
-
+        $userService = new class extends UserService {
             public function changePassword($user, $password)
             {
-                $this->passwordChanges->append([$user, $password]);
-                return $user;
+                TestCase::fail('requestRecovery must not change the password before the user confirms the flow.');
             }
         };
 
@@ -88,20 +82,13 @@ class PasswordRecoveryServiceTest extends TestCase
 
         $service->requestRecovery($payload);
 
-        self::assertCount(1, $passwordChanges);
-        self::assertSame($user, $passwordChanges[0][0]);
-        self::assertMatchesRegularExpression(
-            '/^[ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789]{10}$/',
-            $passwordChanges[0][1]
-        );
-
         self::assertMatchesRegularExpression('/^[a-f0-9]{40}$/', (string) $user->getOauthHash());
-        self::assertMatchesRegularExpression('/^[a-f0-9]{48}$/', (string) $user->getLostPassword());
+        self::assertMatchesRegularExpression('/^\d{10}\.[a-f0-9]{32}$/', (string) $user->getLostPassword());
 
         self::assertCount(1, $emails);
         self::assertSame('maria@example.com', $emails[0]['recipient']);
         self::assertSame('Recuperacao de senha', $emails[0]['subject']);
-        self::assertStringContainsString($passwordChanges[0][1], $emails[0]['body']);
+        self::assertStringNotContainsString('senha temporaria', strtolower($emails[0]['body']));
         self::assertStringContainsString(
             sprintf(
                 'https://admin.controleonline.com/reset-password?hash=%s&amp;lost=%s',
@@ -157,5 +144,140 @@ class PasswordRecoveryServiceTest extends TestCase
         $service->requestRecovery($payload);
 
         self::assertTrue(true);
+    }
+
+    public function testCompleteRecoveryChangesPasswordAndClearsRecoveryTokens(): void
+    {
+        $payload = new \ControleOnline\Entity\RecoveryAccess();
+        $payload->hash = 'hash-token';
+        $payload->lost = (time() + 900) . '.abcdef0123456789abcdef0123456789';
+        $payload->password = 'novaSenha123';
+
+        $people = (new People('Maria Silva'))->setEmails([
+            new Email('maria@example.com'),
+        ]);
+        $user = (new User('maria@example.com', $people))
+            ->setOauthHash('hash-token')
+            ->setLostPassword($payload->lost);
+
+        $userRepository = new class($user) {
+            public function __construct(private User $user)
+            {
+            }
+
+            public function findOneBy(array $criteria): ?User
+            {
+                if (
+                    ($criteria['oauthHash'] ?? null) === $this->user->getOauthHash()
+                    && ($criteria['lostPassword'] ?? null) === $this->user->getLostPassword()
+                ) {
+                    return $this->user;
+                }
+
+                return null;
+            }
+        };
+
+        $manager = $this->createMock(EntityManagerInterface::class);
+        $manager
+            ->expects(self::once())
+            ->method('getRepository')
+            ->with(User::class)
+            ->willReturn($userRepository);
+        $manager->expects(self::once())->method('persist')->with($user);
+        $manager->expects(self::once())->method('flush');
+
+        $passwordChanges = new \ArrayObject();
+        $userService = new class($passwordChanges) extends UserService {
+            public function __construct(private \ArrayObject $passwordChanges)
+            {
+            }
+
+            public function changePassword($user, $password)
+            {
+                $this->passwordChanges->append([$user, $password]);
+                return $user;
+            }
+        };
+
+        $service = new PasswordRecoveryService(
+            $manager,
+            new EmailService(),
+            $userService,
+            new DomainService(),
+        );
+
+        $service->completeRecovery($payload);
+
+        self::assertCount(1, $passwordChanges);
+        self::assertSame('novaSenha123', $passwordChanges[0][1]);
+        self::assertNull($user->getOauthHash());
+        self::assertNull($user->getLostPassword());
+    }
+
+    public function testCompleteRecoveryRejectsExpiredTokensAndClearsRecoveryState(): void
+    {
+        $payload = new \ControleOnline\Entity\RecoveryAccess();
+        $payload->hash = 'hash-token';
+        $payload->lost = (time() - 5) . '.abcdef0123456789abcdef0123456789';
+        $payload->password = 'novaSenha123';
+
+        $people = (new People('Maria Silva'))->setEmails([
+            new Email('maria@example.com'),
+        ]);
+        $user = (new User('maria@example.com', $people))
+            ->setOauthHash('hash-token')
+            ->setLostPassword($payload->lost);
+
+        $userRepository = new class($user) {
+            public function __construct(private User $user)
+            {
+            }
+
+            public function findOneBy(array $criteria): ?User
+            {
+                if (
+                    ($criteria['oauthHash'] ?? null) === $this->user->getOauthHash()
+                    && ($criteria['lostPassword'] ?? null) === $this->user->getLostPassword()
+                ) {
+                    return $this->user;
+                }
+
+                return null;
+            }
+        };
+
+        $manager = $this->createMock(EntityManagerInterface::class);
+        $manager
+            ->expects(self::once())
+            ->method('getRepository')
+            ->with(User::class)
+            ->willReturn($userRepository);
+        $manager->expects(self::once())->method('persist')->with($user);
+        $manager->expects(self::once())->method('flush');
+
+        $userService = new class extends UserService {
+            public function changePassword($user, $password)
+            {
+                TestCase::fail('completeRecovery must not change the password when the recovery token is expired.');
+            }
+        };
+
+        $service = new PasswordRecoveryService(
+            $manager,
+            new EmailService(),
+            $userService,
+            new DomainService(),
+        );
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Solicitacao de recuperacao invalida ou expirada.');
+
+        try {
+            $service->completeRecovery($payload);
+        } finally {
+            self::assertNull($user->getOauthHash());
+            self::assertNull($user->getLostPassword());
+        }
     }
 }

--- a/tests/Service/PasswordRecoveryServiceTest.php
+++ b/tests/Service/PasswordRecoveryServiceTest.php
@@ -104,9 +104,9 @@ class PasswordRecoveryServiceTest extends TestCase
         self::assertStringContainsString($passwordChanges[0][1], $emails[0]['body']);
         self::assertStringContainsString(
             sprintf(
-                'https://admin.controleonline.com/reset-password?hash=%s&lost=%s',
-                rawurlencode((string) $user->getOauthHash()),
-                rawurlencode((string) $user->getLostPassword())
+                'https://admin.controleonline.com/reset-password?hash=%s&amp;lost=%s',
+                htmlspecialchars((string) $user->getOauthHash(), ENT_QUOTES, 'UTF-8'),
+                htmlspecialchars((string) $user->getLostPassword(), ENT_QUOTES, 'UTF-8')
             ),
             $emails[0]['body']
         );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace App\Service {
+    class EmailService
+    {
+        public function sendMessage(string $recipient, string $subject, string $body): void
+        {
+        }
+    }
+}
+
+namespace Doctrine\ORM {
+    interface EntityManagerInterface
+    {
+        public function getRepository(string $class);
+
+        public function persist(object $object): void;
+
+        public function flush(): void;
+    }
+}
+
+namespace Symfony\Component\Validator\Validator {
+    interface ValidatorInterface
+    {
+        public function validate(mixed $value, mixed $constraints = null, mixed $groups = null);
+    }
+}
+
+namespace ControleOnline\Service {
+    class UserService
+    {
+        public function changePassword($user, $password)
+        {
+            return $user;
+        }
+    }
+
+    class DomainService
+    {
+        public function getDomain()
+        {
+            return 'admin.controleonline.com';
+        }
+    }
+}
+
+namespace ControleOnline\Entity {
+    class PasswordRecovery
+    {
+        public ?string $username = null;
+        public ?string $email = null;
+    }
+
+    class RecoveryAccess
+    {
+        public ?string $hash = null;
+        public ?string $lost = null;
+        public ?string $password = null;
+        public ?string $confirm = null;
+    }
+
+    class Email
+    {
+        public function __construct(
+            private string $email = '',
+            private mixed $people = null
+        ) {
+        }
+
+        public function getEmail(): string
+        {
+            return $this->email;
+        }
+
+        public function getPeople(): mixed
+        {
+            return $this->people;
+        }
+    }
+
+    class People
+    {
+        private array $emails = [];
+
+        public function __construct(
+            private string $fullName = ''
+        ) {
+        }
+
+        public function setEmails(array $emails): self
+        {
+            $this->emails = $emails;
+            return $this;
+        }
+
+        public function getFullName(): string
+        {
+            return $this->fullName;
+        }
+
+        public function getEmail(): array
+        {
+            return $this->emails;
+        }
+
+        public function getOneEmail(): ?Email
+        {
+            return $this->emails[0] ?? null;
+        }
+    }
+
+    class User
+    {
+        private ?string $oauthHash = null;
+        private ?string $lostPassword = null;
+
+        public function __construct(
+            private string $username = '',
+            private ?People $people = null
+        ) {
+            $this->people ??= new People($username);
+        }
+
+        public function getUsername(): string
+        {
+            return $this->username;
+        }
+
+        public function setOauthHash(?string $hash): self
+        {
+            $this->oauthHash = $hash;
+            return $this;
+        }
+
+        public function getOauthHash(): ?string
+        {
+            return $this->oauthHash;
+        }
+
+        public function setLostPassword(?string $hash): self
+        {
+            $this->lostPassword = $hash;
+            return $this;
+        }
+
+        public function getLostPassword(): ?string
+        {
+            return $this->lostPassword;
+        }
+
+        public function getPeople(): People
+        {
+            return $this->people;
+        }
+    }
+}
+
+namespace {
+    require_once __DIR__ . '/../src/Service/PasswordRecoveryService.php';
+}


### PR DESCRIPTION
## Summary
- stop the public recovery request from changing the user password before the owner proves possession of the recovery link
- generate short-lived recovery tokens, expire them after 15 minutes, and clear them after successful or expired completion
- extend `PasswordRecoveryService` coverage for the new link-only request path, successful completion, and expired-token rejection
- keep the branch workflow and Scrutinizer override in place so the security fix publishes reviewable evidence on GitHub

## Testing
- focused PHPUnit coverage is published in the branch workflow for `tests/Service/PasswordRecoveryServiceTest.php`
- local execution was not possible in this container because PHP and Composer are unavailable here

Refs: ControleOnline/app-community#94