### PR TITLE
Harden user access controls for app-community#95

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -1,0 +1,28 @@
+name: Pull Request Checks
+
+on:
+  pull_request:
+  push:
+    branches:
+      - task-95
+
+jobs:
+  users-module:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+
+      - name: Validate composer files
+        run: composer validate --no-check-publish
+
+      - name: Install test dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,12 @@
+build:
+  dependencies:
+    override:
+      - composer install --no-interaction --prefer-dist
+
+  project_setup:
+    override:
+      - true
+
+  tests:
+    override:
+      - vendor/bin/phpunit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,10 @@
 - Criar usuario para uma `people`, trocar senha, renovar `apiKey` ou remover usuario so e permitido para operador autorizado sobre a `people` alvo. Receber `people` ou `user id` do cliente nunca e suficiente por si so.
 - Fluxo de autoatendimento pode permitir troca de senha do proprio usuario autenticado, mas isso deve ser separado do fluxo administrativo e continuar restrito ao proprio titular.
 - A exposicao de `apiKey` em resposta de leitura exige a mesma autorizacao forte do fluxo de renovacao; nao pode ficar acessivel a qualquer `ROLE_HUMAN`.
+- Para a entidade `User`, "operador administrativo autorizado" significa apenas vinculos humanos administrativos da empresa alvo: `owner`, `director` ou `manager` (`PeopleLink::MANAGER_LINK`).
+- Vinculos humanos nao administrativos, como `employee`, `salesman` e `after-sales`, nao podem ganhar leitura de colecao, leitura de outro usuario, criacao, exclusao, troca de senha nem renovacao de `apiKey` de terceiros apenas por compartilharem a mesma empresa.
+- O proprio usuario autenticado pode ler apenas o proprio registro; qualquer leitura transversal dentro da empresa exige perfil administrativo.
+- Se existir fluxo de autoatendimento para senha ou `apiKey`, ele deve operar somente sobre o proprio usuario autenticado e nao pode reaproveitar o mesmo criterio administrativo usado para gerir usuarios de terceiros.
 
 ## Limites
 - Dados cadastrais de pessoa e empresa pertencem a `people`.

--- a/README.md
+++ b/README.md
@@ -89,3 +89,17 @@ Current behavior:
 Validation:
 - focused PHPUnit coverage lives in `tests/Service/PasswordRecoveryServiceTest.php`
 - the branch workflow `Pull Request Checks` is the canonical automated evidence for this flow in review branches
+
+## User management scope
+
+The user-management flow used by the manager area now keeps all sensitive operations on the same guarded service path.
+
+Current behavior:
+- direct user reads and management stay restricted by `UserService::securityFilter`
+- cross-person management is limited to `owner`, `director`, and `manager`
+- disabled `people_link` rows and disabled companies no longer authorize reads, deletes, password changes, or API key rotation
+- `DELETE /users/{id}` now follows the same guarded `UserService` path used by create, password-change, and API-key rotation flows
+
+Validation:
+- focused coverage lives in `tests/Service/UserServiceTest.php`, `tests/Controller/DeleteUserActionTest.php`, and `tests/Entity/UserSerializationGroupsTest.php`
+- the branch workflow `Pull Request Checks` is the canonical automated evidence for this flow in review branches

--- a/composer.json
+++ b/composer.json
@@ -15,5 +15,8 @@
             "email": "luiz.kim@controleonline.com"
         }
     ],
-    "require": {}
+    "require": {},
+    "require-dev": {
+        "phpunit/phpunit": "^12.1"
+    }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.1/phpunit.xsd"
+    bootstrap="tests/bootstrap.php"
+    colors="true"
+    cacheDirectory=".phpunit.cache"
+>
+    <testsuites>
+        <testsuite name="Users Module Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Controller/ChangeApiKeyAction.php
+++ b/src/Controller/ChangeApiKeyAction.php
@@ -2,46 +2,48 @@
 
 namespace ControleOnline\Controller;
 
-use Doctrine\ORM\EntityManagerInterface;
-use ControleOnline\Service\HydratorService;
-use Symfony\Component\HttpFoundation\JsonResponse;
 use ControleOnline\Entity\User;
+use ControleOnline\Service\HydratorService;
 use ControleOnline\Service\UserService;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 
 class ChangeApiKeyAction
 {
+    public function __construct(
+        private EntityManagerInterface $manager,
+        private UserService $service,
+        private HydratorService $hydratorService
 
-  public function __construct(
-    private EntityManagerInterface $manager,
-    private UserService $service,
-    private HydratorService $hydratorService
-
-  ) {}
-
-  public function __invoke(User $data)
-  {
-
-    try {
-
-      $user = $this->service->changeApiKey($data);
-
-      return new JsonResponse(
-        $this->hydratorService->item(
-          User::class,
-          $user->getId(),
-          "user:read"
-        )
-      );
-    } catch (\Exception $e) {
-
-      return new JsonResponse([
-        'response' => [
-          'data'    => [],
-          'count'   => 0,
-          'error'   => $e->getMessage(),
-          'success' => false,
-        ],
-      ], 500);
+    ) {
     }
-  }
+
+    public function __invoke(User $data)
+    {
+        try {
+            $user = $this->service->changeApiKey($data);
+
+            return new JsonResponse(
+                $this->hydratorService->item(
+                    User::class,
+                    $user->getId(),
+                    "user:read"
+                )
+            );
+        } catch (\Throwable $e) {
+            $statusCode = $e instanceof HttpExceptionInterface
+                ? $e->getStatusCode()
+                : 500;
+
+            return new JsonResponse([
+                'response' => [
+                    'data' => [],
+                    'count' => 0,
+                    'error' => $e->getMessage(),
+                    'success' => false,
+                ],
+            ], $statusCode);
+        }
+    }
 }

--- a/src/Controller/ChangePasswordAction.php
+++ b/src/Controller/ChangePasswordAction.php
@@ -2,47 +2,50 @@
 
 namespace ControleOnline\Controller;
 
+use ControleOnline\Entity\User;
 use ControleOnline\Service\HydratorService;
+use ControleOnline\Service\UserService;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use ControleOnline\Entity\User;
-use ControleOnline\Service\UserService;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 
 class ChangePasswordAction
 {
+    public function __construct(
+        private UserService $service,
+        private HydratorService $hydratorService
 
-  public function __construct(
-    private UserService $service,
-    private HydratorService $hydratorService
-
-  ) {}
-
-  public function __invoke(User $data, Request $request)
-  {
-
-    try {
-      $user = $this->service->changePasswordFromContent(
-        $data,
-        $request->getContent()
-      );
-
-      return new JsonResponse(
-        $this->hydratorService->item(
-          User::class,
-          $user->getId(),
-          "user:read"
-        )
-      );
-    } catch (\Exception $e) {
-
-      return new JsonResponse([
-        'response' => [
-          'data'    => [],
-          'count'   => 0,
-          'error'   => $e->getMessage(),
-          'success' => false,
-        ],
-      ], 500);
+    ) {
     }
-  }
+
+    public function __invoke(User $data, Request $request)
+    {
+        try {
+            $user = $this->service->changePasswordFromContent(
+                $data,
+                $request->getContent()
+            );
+
+            return new JsonResponse(
+                $this->hydratorService->item(
+                    User::class,
+                    $user->getId(),
+                    "user:read"
+                )
+            );
+        } catch (\Throwable $e) {
+            $statusCode = $e instanceof HttpExceptionInterface
+                ? $e->getStatusCode()
+                : 500;
+
+            return new JsonResponse([
+                'response' => [
+                    'data' => [],
+                    'count' => 0,
+                    'error' => $e->getMessage(),
+                    'success' => false,
+                ],
+            ], $statusCode);
+        }
+    }
 }

--- a/src/Controller/CreateUserAction.php
+++ b/src/Controller/CreateUserAction.php
@@ -4,44 +4,47 @@ namespace ControleOnline\Controller;
 
 use ControleOnline\Entity\User;
 use ControleOnline\Service\HydratorService;
+use ControleOnline\Service\UserService;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use ControleOnline\Service\UserService;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 
 class CreateUserAction
 {
+    public function __construct(
+        private UserService $service,
+        private HydratorService $hydratorService
 
-  public function __construct(
-    private UserService $service,
-    private HydratorService $hydratorService
-
-  ) {}
-
-  public function __invoke(Request $request)
-  {
-
-    try {
-      $user = $this->service->createUserFromContent(
-        $request->getContent()
-      );
-
-      return new JsonResponse(
-        $this->hydratorService->item(
-          User::class,
-          $user->getId(),
-          "user:read"
-        )
-      );
-    } catch (\Exception $e) {
-
-      return new JsonResponse([
-        'response' => [
-          'data'    => [],
-          'count'   => 0,
-          'error'   => $e->getMessage(),
-          'success' => false,
-        ],
-      ], 500);
+    ) {
     }
-  }
+
+    public function __invoke(Request $request)
+    {
+        try {
+            $user = $this->service->createUserFromContent(
+                $request->getContent()
+            );
+
+            return new JsonResponse(
+                $this->hydratorService->item(
+                    User::class,
+                    $user->getId(),
+                    "user:read"
+                )
+            );
+        } catch (\Throwable $e) {
+            $statusCode = $e instanceof HttpExceptionInterface
+                ? $e->getStatusCode()
+                : 500;
+
+            return new JsonResponse([
+                'response' => [
+                    'data' => [],
+                    'count' => 0,
+                    'error' => $e->getMessage(),
+                    'success' => false,
+                ],
+            ], $statusCode);
+        }
+    }
 }

--- a/src/Controller/DeleteUserAction.php
+++ b/src/Controller/DeleteUserAction.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace ControleOnline\Controller;
+
+use ControleOnline\Entity\User;
+use ControleOnline\Service\UserService;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+
+class DeleteUserAction
+{
+    public function __construct(private UserService $service)
+    {
+    }
+
+    public function __invoke(User $data)
+    {
+        try {
+            $this->service->deleteUser($data->getPeople(), (int) $data->getId());
+
+            return new JsonResponse([
+                'response' => [
+                    'data' => [],
+                    'count' => 0,
+                    'error' => null,
+                    'success' => true,
+                ],
+            ]);
+        } catch (\Throwable $e) {
+            $statusCode = $e instanceof HttpExceptionInterface
+                ? $e->getStatusCode()
+                : 500;
+
+            return new JsonResponse([
+                'response' => [
+                    'data' => [],
+                    'count' => 0,
+                    'error' => $e->getMessage(),
+                    'success' => false,
+                ],
+            ], $statusCode);
+        }
+    }
+}

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -75,11 +75,11 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     #[ORM\Column(type: 'integer')]
-    #[Groups(['people:read', 'user:read'])]
+    #[Groups(['user:read'])]
     private ?int $id = null;
 
     #[ORM\Column(type: 'string', length: 50, nullable: false)]
-    #[Groups(['people:read', 'user:read', 'user:write'])]
+    #[Groups(['user:read', 'user:write'])]
     #[Assert\NotBlank(message: 'O e-mail é obrigatório.')]
     #[Assert\Email(message: 'O valor "{{ value }}" não é um e-mail válido.')]
     private string $username = '';
@@ -97,7 +97,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     private ?string $lostPassword = null;
 
     #[ORM\Column(type: 'string', length: 60, nullable: false)]
-    #[Groups(['people:read', 'user:read'])]
+    #[Groups(['user:read'])]
     private string $apiKey = '';
 
     #[ORM\ManyToOne(targetEntity: People::class, inversedBy: 'user')]

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -16,6 +16,7 @@ use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
 use ControleOnline\Controller\ChangeApiKeyAction;
 use ControleOnline\Controller\ChangePasswordAction;
 use ControleOnline\Controller\CreateUserAction;
+use ControleOnline\Controller\DeleteUserAction;
 use ControleOnline\Controller\SecurityController;
 use ControleOnline\Entity\People;
 use ControleOnline\Repository\UserRepository;
@@ -37,7 +38,11 @@ use Doctrine\ORM\Mapping as ORM;
             controller: CreateUserAction::class,
             securityPostDenormalize: 'is_granted(\'ROLE_HUMAN\')',
         ),
-        new Delete(security: 'is_granted(\'ROLE_HUMAN\')'),
+        new Delete(
+            uriTemplate: '/users/{id}',
+            controller: DeleteUserAction::class,
+            security: 'is_granted(\'ROLE_HUMAN\')',
+        ),
         new Put(
             uriTemplate: '/users/{id}/change-api-key',
             controller: ChangeApiKeyAction::class,

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -281,7 +281,10 @@ class UserService
         $myPeople = $this->getMyPeople();
         $managedCompanyIds = array_map(
             static fn(People $company): int => (int) $company->getId(),
-            $this->getManagedCompanies()
+            array_filter(
+                $this->getManagedCompanies(),
+                fn(People $company): bool => $this->isPeopleEnabled($company)
+            )
         );
 
         if (!$myPeople instanceof People && $managedCompanyIds === []) {
@@ -300,7 +303,22 @@ class UserService
                 PeopleLink::class,
                 $peopleLinkAlias,
                 'WITH',
-                sprintf('%s.people = %s.id', $peopleLinkAlias, $peopleAlias)
+                sprintf(
+                    '%s.people = %s.id AND %s.enable = true',
+                    $peopleLinkAlias,
+                    $peopleAlias,
+                    $peopleLinkAlias
+                )
+            );
+        }
+
+        $companyAlias = 'user_people_company';
+        if (!in_array($companyAlias, $queryBuilder->getAllAliases(), true)) {
+            $queryBuilder->leftJoin(
+                sprintf('%s.company', $peopleLinkAlias),
+                $companyAlias,
+                'WITH',
+                sprintf('%s.enabled = true', $companyAlias)
             );
         }
 
@@ -311,7 +329,7 @@ class UserService
         }
 
         if ($managedCompanyIds !== []) {
-            $visibilityConditions[] = sprintf('%s.company IN(:managedCompanies)', $peopleLinkAlias);
+            $visibilityConditions[] = sprintf('%s.id IN(:managedCompanies)', $companyAlias);
             $queryBuilder->setParameter('managedCompanies', $managedCompanyIds);
         }
 
@@ -377,7 +395,10 @@ class UserService
 
         $managedCompanyIds = array_map(
             static fn(People $company): int => (int) $company->getId(),
-            $this->getManagedCompanies()
+            array_filter(
+                $this->getManagedCompanies(),
+                fn(People $company): bool => $this->isPeopleEnabled($company)
+            )
         );
 
         if ($managedCompanyIds === []) {
@@ -392,17 +413,37 @@ class UserService
         $companyIds = [];
 
         foreach ($people->getLink() as $link) {
-            if (!$link instanceof PeopleLink) {
+            if (!$link instanceof PeopleLink || !$this->isLinkEnabled($link)) {
                 continue;
             }
 
             $company = $link->getCompany();
-            if ($company instanceof People) {
-                $companyIds[] = (int) $company->getId();
+            if (!$company instanceof People || !$this->isPeopleEnabled($company)) {
+                continue;
             }
+
+            $companyIds[] = (int) $company->getId();
         }
 
         return array_values(array_unique(array_filter($companyIds)));
+    }
+
+    private function isLinkEnabled(PeopleLink $link): bool
+    {
+        if (!method_exists($link, 'getEnabled')) {
+            return true;
+        }
+
+        return (bool) $link->getEnabled();
+    }
+
+    private function isPeopleEnabled(People $people): bool
+    {
+        if (!method_exists($people, 'getEnabled')) {
+            return true;
+        }
+
+        return (bool) $people->getEnabled();
     }
 
     private function decodePayload(?string $content): array

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -279,12 +279,12 @@ class UserService
     public function securityFilter(QueryBuilder $queryBuilder, $resourceClass = null, $applyTo = null, $rootAlias = null): void
     {
         $myPeople = $this->getMyPeople();
-        $myCompanyIds = array_map(
+        $managedCompanyIds = array_map(
             static fn(People $company): int => (int) $company->getId(),
-            $this->getMyCompanies()
+            $this->getManagedCompanies()
         );
 
-        if (!$myPeople instanceof People && $myCompanyIds === []) {
+        if (!$myPeople instanceof People && $managedCompanyIds === []) {
             $queryBuilder->andWhere('1 = 0');
             return;
         }
@@ -310,9 +310,9 @@ class UserService
             $queryBuilder->setParameter('myPeopleId', (int) $myPeople->getId());
         }
 
-        if ($myCompanyIds !== []) {
-            $visibilityConditions[] = sprintf('%s.company IN(:myCompanies)', $peopleLinkAlias);
-            $queryBuilder->setParameter('myCompanies', $myCompanyIds);
+        if ($managedCompanyIds !== []) {
+            $visibilityConditions[] = sprintf('%s.company IN(:managedCompanies)', $peopleLinkAlias);
+            $queryBuilder->setParameter('managedCompanies', $managedCompanyIds);
         }
 
         if ($visibilityConditions === []) {
@@ -346,6 +346,14 @@ class UserService
         );
     }
 
+    public function getManagedCompanies(): array
+    {
+        return $this->peopleRoleService->getAccessibleCompaniesForPeople(
+            $this->getMyPeople(),
+            PeopleLink::MANAGER_LINK
+        );
+    }
+
     private function denyUnlessCanManagePeople(People $people): void
     {
         if ($this->canManagePeople($people)) {
@@ -367,16 +375,16 @@ class UserService
             return false;
         }
 
-        $myCompanyIds = array_map(
+        $managedCompanyIds = array_map(
             static fn(People $company): int => (int) $company->getId(),
-            $this->getMyCompanies()
+            $this->getManagedCompanies()
         );
 
-        if ($myCompanyIds === []) {
+        if ($managedCompanyIds === []) {
             return false;
         }
 
-        return array_intersect($myCompanyIds, $targetCompanyIds) !== [];
+        return array_intersect($managedCompanyIds, $targetCompanyIds) !== [];
     }
 
     private function getCompanyIdsForPeople(People $people): array

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -5,26 +5,35 @@ namespace ControleOnline\Service;
 use ControleOnline\Entity\Email;
 use ControleOnline\Entity\Language;
 use ControleOnline\Entity\People;
+use ControleOnline\Entity\PeopleLink;
 use ControleOnline\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\QueryBuilder;
 use Exception;
-use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface as Security;
 
 class UserService
 {
+    private $request;
+
     public function __construct(
         private EntityManagerInterface $manager,
         private UserPasswordHasherInterface $passwordHasher,
         private FileService $fileService,
+        private Security $security,
         private PeopleRoleService $peopleRoleService,
-    ) {}
+        private RequestStack $requestStack,
+    ) {
+        $this->request = $requestStack->getCurrentRequest();
+    }
 
     public function changePassword(User $user, $password)
     {
-        if (!$this->getPermission()) {
-            throw new Exception("You should not pass!!!", 301);
-        }
+        $this->denyUnlessCanManagePeople($user->getPeople());
 
         $hashedPassword = $this->passwordHasher->hashPassword($user, $password);
         $user->setHash($hashedPassword);
@@ -46,9 +55,7 @@ class UserService
 
     public function changeApiKey(User $user)
     {
-        if (!$this->getPermission()) {
-            throw new Exception("You should not pass!!!", 301);
-        }
+        $this->denyUnlessCanManagePeople($user->getPeople());
 
         $user->generateApiKey();
 
@@ -160,9 +167,7 @@ class UserService
 
     public function createUser(People $people, $username, $password)
     {
-        if (!$this->getPermission()) {
-            throw new Exception("You should not pass!!!", 301);
-        }
+        $this->denyUnlessCanManagePeople($people);
 
         $user = $this->manager->getRepository(User::class)
             ->findOneBy([
@@ -209,6 +214,8 @@ class UserService
 
     public function deleteUser(People $person, int $userId): bool
     {
+        $this->denyUnlessCanManagePeople($person);
+
         try {
             $this->manager->getConnection()->beginTransaction();
 
@@ -269,12 +276,125 @@ class UserService
         return $company ? $company->getId() : null;
     }
 
-    /**
-     * @todo arrumar
-     */
-    private function getPermission()
+    public function securityFilter(QueryBuilder $queryBuilder, $resourceClass = null, $applyTo = null, $rootAlias = null): void
     {
-        return true;
+        $myPeople = $this->getMyPeople();
+        $myCompanyIds = array_map(
+            static fn(People $company): int => (int) $company->getId(),
+            $this->getMyCompanies()
+        );
+
+        if (!$myPeople instanceof People && $myCompanyIds === []) {
+            $queryBuilder->andWhere('1 = 0');
+            return;
+        }
+
+        $peopleAlias = 'user_people';
+        if (!in_array($peopleAlias, $queryBuilder->getAllAliases(), true)) {
+            $queryBuilder->innerJoin(sprintf('%s.people', $rootAlias), $peopleAlias);
+        }
+
+        $peopleLinkAlias = 'user_people_link';
+        if (!in_array($peopleLinkAlias, $queryBuilder->getAllAliases(), true)) {
+            $queryBuilder->leftJoin(
+                PeopleLink::class,
+                $peopleLinkAlias,
+                'WITH',
+                sprintf('%s.people = %s.id', $peopleLinkAlias, $peopleAlias)
+            );
+        }
+
+        $visibilityConditions = [];
+        if ($myPeople instanceof People) {
+            $visibilityConditions[] = sprintf('%s.id = :myPeopleId', $peopleAlias);
+            $queryBuilder->setParameter('myPeopleId', (int) $myPeople->getId());
+        }
+
+        if ($myCompanyIds !== []) {
+            $visibilityConditions[] = sprintf('%s.company IN(:myCompanies)', $peopleLinkAlias);
+            $queryBuilder->setParameter('myCompanies', $myCompanyIds);
+        }
+
+        if ($visibilityConditions === []) {
+            $queryBuilder->andWhere('1 = 0');
+            return;
+        }
+
+        $queryBuilder->andWhere($queryBuilder->expr()->orX(...$visibilityConditions));
+    }
+
+    public function getMyPeople(): ?People
+    {
+        $token = $this->security->getToken();
+        if (!$token) {
+            return null;
+        }
+
+        $currentUser = $token->getUser();
+        if (!is_object($currentUser) || !method_exists($currentUser, 'getPeople')) {
+            return null;
+        }
+
+        return $currentUser->getPeople();
+    }
+
+    public function getMyCompanies(): array
+    {
+        return $this->peopleRoleService->getAccessibleCompaniesForPeople(
+            $this->getMyPeople(),
+            PeopleLink::EMPLOYEE_LINK
+        );
+    }
+
+    private function denyUnlessCanManagePeople(People $people): void
+    {
+        if ($this->canManagePeople($people)) {
+            return;
+        }
+
+        throw new AccessDeniedHttpException('You should not pass!!!');
+    }
+
+    private function canManagePeople(People $people): bool
+    {
+        $myPeople = $this->getMyPeople();
+        if (!$myPeople instanceof People) {
+            return false;
+        }
+
+        $targetCompanyIds = $this->getCompanyIdsForPeople($people);
+        if ($targetCompanyIds === []) {
+            return false;
+        }
+
+        $myCompanyIds = array_map(
+            static fn(People $company): int => (int) $company->getId(),
+            $this->getMyCompanies()
+        );
+
+        if ($myCompanyIds === []) {
+            return false;
+        }
+
+        return array_intersect($myCompanyIds, $targetCompanyIds) !== [];
+    }
+
+    private function getCompanyIdsForPeople(People $people): array
+    {
+        $companyIds = [];
+
+        foreach ($people->getLink() as $link) {
+            if (!$link instanceof PeopleLink) {
+                continue;
+            }
+
+            $company = $link->getCompany();
+            if ($company instanceof People) {
+                $companyIds[] = (int) $company->getId();
+            }
+        }
+
+        return array_values(array_unique(array_filter($companyIds)));
     }
 
     private function decodePayload(?string $content): array

--- a/tests/Controller/DeleteUserActionTest.php
+++ b/tests/Controller/DeleteUserActionTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace ControleOnline\Users\Tests\Controller;
+
+use ControleOnline\Controller\DeleteUserAction;
+use ControleOnline\Entity\People;
+use ControleOnline\Entity\User;
+use ControleOnline\Service\UserService;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+class DeleteUserActionTest extends TestCase
+{
+    public function testInvokeDelegatesDeletionToUserService(): void
+    {
+        $people = new People(7);
+        $user = (new User())
+            ->setId(11)
+            ->setPeople($people);
+
+        $service = $this->createMock(UserService::class);
+        $service
+            ->expects(self::once())
+            ->method('deleteUser')
+            ->with($people, 11)
+            ->willReturn(true);
+
+        $response = (new DeleteUserAction($service))->__invoke($user);
+
+        self::assertInstanceOf(JsonResponse::class, $response);
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame([
+            'response' => [
+                'data' => [],
+                'count' => 0,
+                'error' => null,
+                'success' => true,
+            ],
+        ], $response->getData(true));
+    }
+}

--- a/tests/Entity/UserSerializationGroupsTest.php
+++ b/tests/Entity/UserSerializationGroupsTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace ControleOnline\Users\Tests\Entity;
+
+use PHPUnit\Framework\TestCase;
+
+class UserSerializationGroupsTest extends TestCase
+{
+    public function testUserSecretsAreNotSerializedThroughPeopleRead(): void
+    {
+        $source = file_get_contents(__DIR__ . '/../../src/Entity/User.php');
+
+        self::assertIsString($source);
+        self::assertDoesNotMatchRegularExpression('/#\[Groups\(\[(?:(?!\]\)\]).)*people:read(?:(?!\]\)\]).)*\]\)\]\s*private \?int \$id = null;/s', $source);
+        self::assertDoesNotMatchRegularExpression('/#\[Groups\(\[(?:(?!\]\)\]).)*people:read(?:(?!\]\)\]).)*\]\)\]\s*#\[Assert\\NotBlank.*?private string \$username = \'\';/s', $source);
+        self::assertDoesNotMatchRegularExpression('/#\[Groups\(\[(?:(?!\]\)\]).)*people:read(?:(?!\]\)\]).)*\]\)\]\s*private string \$apiKey = \'\';/s', $source);
+    }
+}

--- a/tests/Service/UserServiceTest.php
+++ b/tests/Service/UserServiceTest.php
@@ -92,6 +92,42 @@ class UserServiceTest extends TestCase
         $service->createUser($targetPeople, 'blocked@example.com', 'secret');
     }
 
+    public function testDeleteUserRejectsPeopleWhoseOnlyLinkIsDisabled(): void
+    {
+        $company = new People(10);
+        $currentPeople = new People(1, new \ControleOnline\Entity\LinkCollection([
+            new PeopleLink($company),
+        ]));
+        $targetPeople = new People(2, new \ControleOnline\Entity\LinkCollection([
+            new PeopleLink($company, false),
+        ]));
+
+        $manager = $this->createMock(EntityManagerInterface::class);
+
+        $service = $this->buildService($manager, $currentPeople, [$company], [$company]);
+
+        $this->expectException(AccessDeniedHttpException::class);
+        $service->deleteUser($targetPeople, 99);
+    }
+
+    public function testDeleteUserRejectsPeopleWhoseCompanyIsDisabled(): void
+    {
+        $company = new People(10, null, 0);
+        $currentPeople = new People(1, new \ControleOnline\Entity\LinkCollection([
+            new PeopleLink(new People(10)),
+        ]));
+        $targetPeople = new People(2, new \ControleOnline\Entity\LinkCollection([
+            new PeopleLink($company),
+        ]));
+
+        $manager = $this->createMock(EntityManagerInterface::class);
+
+        $service = $this->buildService($manager, $currentPeople, [new People(10)], [new People(10)]);
+
+        $this->expectException(AccessDeniedHttpException::class);
+        $service->deleteUser($targetPeople, 99);
+    }
+
     public function testSecurityFilterRestrictsUsersToSelfAndAdministrativeCompanies(): void
     {
         $company = new People(10);
@@ -152,11 +188,13 @@ class UserServiceTest extends TestCase
 
         $service->securityFilter($queryBuilder, User::class, 'collection', 'u');
 
-        self::assertCount(2, $queryBuilder->joins);
+        self::assertCount(3, $queryBuilder->joins);
+        self::assertSame('user_people_link.people = user_people.id AND user_people_link.enable = true', $queryBuilder->joins[1][3]);
+        self::assertSame('user_people_company.enabled = true', $queryBuilder->joins[2][3]);
         self::assertSame([10], $queryBuilder->parameters['managedCompanies']);
         self::assertSame(1, $queryBuilder->parameters['myPeopleId']);
         self::assertStringContainsString('user_people.id = :myPeopleId', $queryBuilder->conditions[0]);
-        self::assertStringContainsString('user_people_link.company IN(:managedCompanies)', $queryBuilder->conditions[0]);
+        self::assertStringContainsString('user_people_company.id IN(:managedCompanies)', $queryBuilder->conditions[0]);
     }
 
     public function testSecurityFilterFallsBackToSelfWhenUserHasNoAdministrativeCompanies(): void

--- a/tests/Service/UserServiceTest.php
+++ b/tests/Service/UserServiceTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
 
 class UserServiceTest extends TestCase
 {
-    public function testCreateUserAllowsManagingPeopleFromAccessibleCompany(): void
+    public function testCreateUserAllowsManagingPeopleFromAdministrativeCompany(): void
     {
         $company = new People(10);
         $currentPeople = new People(1, new \ControleOnline\Entity\LinkCollection([
@@ -44,7 +44,7 @@ class UserServiceTest extends TestCase
         $manager->expects(self::once())->method('persist');
         $manager->expects(self::once())->method('flush');
 
-        $service = $this->buildService($manager, $currentPeople, [$company]);
+        $service = $this->buildService($manager, $currentPeople, [$company], [$company]);
 
         $created = $service->createUser($targetPeople, 'manager@example.com', 'secret');
 
@@ -53,7 +53,27 @@ class UserServiceTest extends TestCase
         self::assertSame('hashed-secret', $created->getHash());
     }
 
-    public function testCreateUserRejectsPeopleOutsideAccessibleCompanies(): void
+    public function testCreateUserRejectsPeopleWhenUserOnlyHasNonAdministrativeLink(): void
+    {
+        $company = new People(10);
+        $currentPeople = new People(1, new \ControleOnline\Entity\LinkCollection([
+            new PeopleLink($company),
+        ]));
+        $targetPeople = new People(2, new \ControleOnline\Entity\LinkCollection([
+            new PeopleLink($company),
+        ]));
+
+        $manager = $this->createMock(EntityManagerInterface::class);
+        $manager->expects(self::never())->method('persist');
+        $manager->expects(self::never())->method('flush');
+
+        $service = $this->buildService($manager, $currentPeople, [$company], []);
+
+        $this->expectException(AccessDeniedHttpException::class);
+        $service->createUser($targetPeople, 'blocked@example.com', 'secret');
+    }
+
+    public function testCreateUserRejectsPeopleOutsideAdministrativeCompanies(): void
     {
         $currentPeople = new People(1, new \ControleOnline\Entity\LinkCollection([
             new PeopleLink(new People(10)),
@@ -66,13 +86,13 @@ class UserServiceTest extends TestCase
         $manager->expects(self::never())->method('persist');
         $manager->expects(self::never())->method('flush');
 
-        $service = $this->buildService($manager, $currentPeople, [new People(10)]);
+        $service = $this->buildService($manager, $currentPeople, [new People(10)], [new People(10)]);
 
         $this->expectException(AccessDeniedHttpException::class);
         $service->createUser($targetPeople, 'blocked@example.com', 'secret');
     }
 
-    public function testSecurityFilterRestrictsUsersToSelfAndAccessibleCompanies(): void
+    public function testSecurityFilterRestrictsUsersToSelfAndAdministrativeCompanies(): void
     {
         $company = new People(10);
         $currentPeople = new People(1, new \ControleOnline\Entity\LinkCollection([
@@ -80,7 +100,7 @@ class UserServiceTest extends TestCase
         ]));
 
         $manager = $this->createMock(EntityManagerInterface::class);
-        $service = $this->buildService($manager, $currentPeople, [$company]);
+        $service = $this->buildService($manager, $currentPeople, [$company], [$company]);
 
         $queryBuilder = new class extends QueryBuilder {
             public array $aliases = ['u'];
@@ -133,16 +153,82 @@ class UserServiceTest extends TestCase
         $service->securityFilter($queryBuilder, User::class, 'collection', 'u');
 
         self::assertCount(2, $queryBuilder->joins);
-        self::assertSame([10], $queryBuilder->parameters['myCompanies']);
+        self::assertSame([10], $queryBuilder->parameters['managedCompanies']);
         self::assertSame(1, $queryBuilder->parameters['myPeopleId']);
         self::assertStringContainsString('user_people.id = :myPeopleId', $queryBuilder->conditions[0]);
-        self::assertStringContainsString('user_people_link.company IN(:myCompanies)', $queryBuilder->conditions[0]);
+        self::assertStringContainsString('user_people_link.company IN(:managedCompanies)', $queryBuilder->conditions[0]);
+    }
+
+    public function testSecurityFilterFallsBackToSelfWhenUserHasNoAdministrativeCompanies(): void
+    {
+        $company = new People(10);
+        $currentPeople = new People(1, new \ControleOnline\Entity\LinkCollection([
+            new PeopleLink($company),
+        ]));
+
+        $manager = $this->createMock(EntityManagerInterface::class);
+        $service = $this->buildService($manager, $currentPeople, [$company], []);
+
+        $queryBuilder = new class extends QueryBuilder {
+            public array $aliases = ['u'];
+            public array $joins = [];
+            public array $conditions = [];
+            public array $parameters = [];
+
+            public function getAllAliases()
+            {
+                return $this->aliases;
+            }
+
+            public function innerJoin($join, $alias, $conditionType = null, $condition = null)
+            {
+                $this->aliases[] = $alias;
+                $this->joins[] = ['inner', $join, $alias, $condition];
+                return $this;
+            }
+
+            public function leftJoin($join, $alias, $conditionType = null, $condition = null)
+            {
+                $this->aliases[] = $alias;
+                $this->joins[] = ['left', $join, $alias, $condition];
+                return $this;
+            }
+
+            public function andWhere($condition)
+            {
+                $this->conditions[] = $condition;
+                return $this;
+            }
+
+            public function setParameter($key, $value, $type = null)
+            {
+                $this->parameters[$key] = $value;
+                return $this;
+            }
+
+            public function expr()
+            {
+                return new class {
+                    public function orX(...$conditions): string
+                    {
+                        return implode(' OR ', $conditions);
+                    }
+                };
+            }
+        };
+
+        $service->securityFilter($queryBuilder, User::class, 'collection', 'u');
+
+        self::assertArrayNotHasKey('managedCompanies', $queryBuilder->parameters);
+        self::assertSame(1, $queryBuilder->parameters['myPeopleId']);
+        self::assertSame('user_people.id = :myPeopleId', $queryBuilder->conditions[0]);
     }
 
     private function buildService(
         EntityManagerInterface $manager,
         People $currentPeople,
-        array $companies
+        array $employeeCompanies,
+        array $managedCompanies
     ): UserService {
         $currentUser = (new User())->setPeople($currentPeople);
 
@@ -182,7 +268,10 @@ class UserServiceTest extends TestCase
             $hasher,
             new FileService(),
             $security,
-            new PeopleRoleService($companies),
+            new PeopleRoleService([
+                'employee' => $employeeCompanies,
+                'manager' => $managedCompanies,
+            ]),
             $requestStack
         );
     }

--- a/tests/Service/UserServiceTest.php
+++ b/tests/Service/UserServiceTest.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace ControleOnline\Users\Tests\Service;
+
+use ControleOnline\Entity\People;
+use ControleOnline\Entity\PeopleLink;
+use ControleOnline\Entity\User;
+use ControleOnline\Service\FileService;
+use ControleOnline\Service\PeopleRoleService;
+use ControleOnline\Service\UserService;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\QueryBuilder;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+class UserServiceTest extends TestCase
+{
+    public function testCreateUserAllowsManagingPeopleFromAccessibleCompany(): void
+    {
+        $company = new People(10);
+        $currentPeople = new People(1, new \ControleOnline\Entity\LinkCollection([
+            new PeopleLink($company),
+        ]));
+        $targetPeople = new People(2, new \ControleOnline\Entity\LinkCollection([
+            new PeopleLink($company),
+        ]));
+
+        $existingUserRepository = new class {
+            public function findOneBy(array $criteria): ?User
+            {
+                return null;
+            }
+        };
+
+        $manager = $this->createMock(EntityManagerInterface::class);
+        $manager
+            ->expects(self::once())
+            ->method('getRepository')
+            ->with(User::class)
+            ->willReturn($existingUserRepository);
+        $manager->expects(self::once())->method('persist');
+        $manager->expects(self::once())->method('flush');
+
+        $service = $this->buildService($manager, $currentPeople, [$company]);
+
+        $created = $service->createUser($targetPeople, 'manager@example.com', 'secret');
+
+        self::assertSame($targetPeople, $created->getPeople());
+        self::assertSame('manager@example.com', $created->getUsername());
+        self::assertSame('hashed-secret', $created->getHash());
+    }
+
+    public function testCreateUserRejectsPeopleOutsideAccessibleCompanies(): void
+    {
+        $currentPeople = new People(1, new \ControleOnline\Entity\LinkCollection([
+            new PeopleLink(new People(10)),
+        ]));
+        $targetPeople = new People(2, new \ControleOnline\Entity\LinkCollection([
+            new PeopleLink(new People(20)),
+        ]));
+
+        $manager = $this->createMock(EntityManagerInterface::class);
+        $manager->expects(self::never())->method('persist');
+        $manager->expects(self::never())->method('flush');
+
+        $service = $this->buildService($manager, $currentPeople, [new People(10)]);
+
+        $this->expectException(AccessDeniedHttpException::class);
+        $service->createUser($targetPeople, 'blocked@example.com', 'secret');
+    }
+
+    public function testSecurityFilterRestrictsUsersToSelfAndAccessibleCompanies(): void
+    {
+        $company = new People(10);
+        $currentPeople = new People(1, new \ControleOnline\Entity\LinkCollection([
+            new PeopleLink($company),
+        ]));
+
+        $manager = $this->createMock(EntityManagerInterface::class);
+        $service = $this->buildService($manager, $currentPeople, [$company]);
+
+        $queryBuilder = new class extends QueryBuilder {
+            public array $aliases = ['u'];
+            public array $joins = [];
+            public array $conditions = [];
+            public array $parameters = [];
+
+            public function getAllAliases()
+            {
+                return $this->aliases;
+            }
+
+            public function innerJoin($join, $alias, $conditionType = null, $condition = null)
+            {
+                $this->aliases[] = $alias;
+                $this->joins[] = ['inner', $join, $alias, $condition];
+                return $this;
+            }
+
+            public function leftJoin($join, $alias, $conditionType = null, $condition = null)
+            {
+                $this->aliases[] = $alias;
+                $this->joins[] = ['left', $join, $alias, $condition];
+                return $this;
+            }
+
+            public function andWhere($condition)
+            {
+                $this->conditions[] = $condition;
+                return $this;
+            }
+
+            public function setParameter($key, $value, $type = null)
+            {
+                $this->parameters[$key] = $value;
+                return $this;
+            }
+
+            public function expr()
+            {
+                return new class {
+                    public function orX(...$conditions): string
+                    {
+                        return implode(' OR ', $conditions);
+                    }
+                };
+            }
+        };
+
+        $service->securityFilter($queryBuilder, User::class, 'collection', 'u');
+
+        self::assertCount(2, $queryBuilder->joins);
+        self::assertSame([10], $queryBuilder->parameters['myCompanies']);
+        self::assertSame(1, $queryBuilder->parameters['myPeopleId']);
+        self::assertStringContainsString('user_people.id = :myPeopleId', $queryBuilder->conditions[0]);
+        self::assertStringContainsString('user_people_link.company IN(:myCompanies)', $queryBuilder->conditions[0]);
+    }
+
+    private function buildService(
+        EntityManagerInterface $manager,
+        People $currentPeople,
+        array $companies
+    ): UserService {
+        $currentUser = (new User())->setPeople($currentPeople);
+
+        $token = new class($currentUser) implements \Symfony\Component\Security\Core\Authentication\Token\TokenInterface {
+            public function __construct(private User $user)
+            {
+            }
+
+            public function getUser(): User
+            {
+                return $this->user;
+            }
+        };
+
+        $security = new class($token) implements TokenStorageInterface {
+            public function __construct(private $token)
+            {
+            }
+
+            public function getToken(): ?\Symfony\Component\Security\Core\Authentication\Token\TokenInterface
+            {
+                return $this->token;
+            }
+        };
+
+        $hasher = new class implements UserPasswordHasherInterface {
+            public function hashPassword(object $user, string $plainPassword): string
+            {
+                return 'hashed-' . $plainPassword;
+            }
+        };
+
+        $requestStack = new RequestStack();
+
+        return new UserService(
+            $manager,
+            $hasher,
+            new FileService(),
+            $security,
+            new PeopleRoleService($companies),
+            $requestStack
+        );
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,309 @@
+<?php
+
+namespace Doctrine\ORM {
+    interface EntityManagerInterface
+    {
+        public function getRepository(string $class);
+
+        public function persist(object $object): void;
+
+        public function flush(): void;
+    }
+
+    abstract class QueryBuilder
+    {
+        abstract public function getAllAliases();
+
+        abstract public function innerJoin($join, $alias, $conditionType = null, $condition = null);
+
+        abstract public function leftJoin($join, $alias, $conditionType = null, $condition = null);
+
+        abstract public function andWhere($condition);
+
+        abstract public function setParameter($key, $value, $type = null);
+
+        abstract public function expr();
+    }
+}
+
+namespace Symfony\Component\HttpFoundation {
+    class RequestStack
+    {
+        public function getCurrentRequest(): mixed
+        {
+            return null;
+        }
+    }
+}
+
+namespace Symfony\Component\HttpKernel\Exception {
+    class BadRequestHttpException extends \RuntimeException
+    {
+    }
+
+    class AccessDeniedHttpException extends \RuntimeException
+    {
+    }
+}
+
+namespace Symfony\Component\PasswordHasher\Hasher {
+    interface UserPasswordHasherInterface
+    {
+        public function hashPassword(object $user, string $plainPassword): string;
+    }
+}
+
+namespace Symfony\Component\Security\Core\Authentication\Token {
+    interface TokenInterface
+    {
+        public function getUser();
+    }
+}
+
+namespace Symfony\Component\Security\Core\Authentication\Token\Storage {
+    use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+    interface TokenStorageInterface
+    {
+        public function getToken(): ?TokenInterface;
+    }
+}
+
+namespace ControleOnline\Entity {
+    class Email
+    {
+        public function setEmail(string $email): self
+        {
+            return $this;
+        }
+
+        public function setPeople(People $people): self
+        {
+            return $this;
+        }
+    }
+
+    class Language
+    {
+    }
+
+    class PeopleLink
+    {
+        public const EMPLOYEE_LINK = ['employee'];
+
+        public function __construct(private ?People $company = null)
+        {
+        }
+
+        public function getCompany(): ?People
+        {
+            return $this->company;
+        }
+    }
+
+    class LinkCollection implements \IteratorAggregate
+    {
+        public function __construct(private array $items = [])
+        {
+        }
+
+        public function first(): mixed
+        {
+            return $this->items[0] ?? false;
+        }
+
+        public function getIterator(): \Traversable
+        {
+            return new \ArrayIterator($this->items);
+        }
+    }
+
+    class User
+    {
+        private ?int $id = null;
+        private ?People $people = null;
+        private string $username = '';
+        private string $hash = '';
+        private string $apiKey = 'initial-key';
+
+        public function getId(): ?int
+        {
+            return $this->id;
+        }
+
+        public function setId(int $id): self
+        {
+            $this->id = $id;
+            return $this;
+        }
+
+        public function setPeople(People $people): self
+        {
+            $this->people = $people;
+            return $this;
+        }
+
+        public function getPeople(): People
+        {
+            return $this->people;
+        }
+
+        public function setUsername(string $username): self
+        {
+            $this->username = $username;
+            return $this;
+        }
+
+        public function getUsername(): string
+        {
+            return $this->username;
+        }
+
+        public function setHash(string $hash): self
+        {
+            $this->hash = $hash;
+            return $this;
+        }
+
+        public function getHash(): string
+        {
+            return $this->hash;
+        }
+
+        public function generateApiKey(): string
+        {
+            $this->apiKey = 'rotated-key';
+            return $this->apiKey;
+        }
+
+        public function getApiKey(): string
+        {
+            return $this->apiKey;
+        }
+
+        public function setResolvedRoles(array $roles): self
+        {
+            return $this;
+        }
+    }
+
+    class People
+    {
+        public function __construct(
+            private int $id = 0,
+            private LinkCollection $link = new LinkCollection()
+        ) {
+        }
+
+        public function getId(): int
+        {
+            return $this->id;
+        }
+
+        public function getLink(): LinkCollection
+        {
+            return $this->link;
+        }
+
+        public function getEmail(): object
+        {
+            return new class {
+                public function count(): int
+                {
+                    return 0;
+                }
+
+                public function first(): mixed
+                {
+                    return null;
+                }
+            };
+        }
+
+        public function getPhone(): object
+        {
+            return new class {
+                public function count(): int
+                {
+                    return 0;
+                }
+
+                public function first(): mixed
+                {
+                    return null;
+                }
+            };
+        }
+
+        public function getName(): string
+        {
+            return 'People';
+        }
+
+        public function getAlias(): string
+        {
+            return 'Alias';
+        }
+
+        public function getLanguage(): ?object
+        {
+            return null;
+        }
+
+        public function getEnabled(): int
+        {
+            return 1;
+        }
+
+        public function getPeopleType(): string
+        {
+            return 'F';
+        }
+
+        public function setAlias(string $alias): self
+        {
+            return $this;
+        }
+
+        public function setName(string $name): self
+        {
+            return $this;
+        }
+
+        public function setLanguage(Language $language): self
+        {
+            return $this;
+        }
+    }
+}
+
+namespace ControleOnline\Service {
+    class FileService
+    {
+        public function getFileUrl($people): string
+        {
+            return '';
+        }
+    }
+
+    class PeopleRoleService
+    {
+        public function __construct(private array $companies = [])
+        {
+        }
+
+        public function getGrantedRoles($people): array
+        {
+            return ['ROLE_HUMAN'];
+        }
+
+        public function getAccessibleCompaniesForPeople($people, $companyType = null): array
+        {
+            return $this->companies;
+        }
+    }
+}
+
+namespace {
+    require_once __DIR__ . '/../src/Service/UserService.php';
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,6 +8,10 @@ namespace Doctrine\ORM {
         public function persist(object $object): void;
 
         public function flush(): void;
+
+        public function remove(object $object): void;
+
+        public function getConnection();
     }
 
     abstract class QueryBuilder
@@ -27,6 +31,25 @@ namespace Doctrine\ORM {
 }
 
 namespace Symfony\Component\HttpFoundation {
+    class JsonResponse
+    {
+        public function __construct(
+            private array $data = [],
+            private int $status = 200
+        ) {
+        }
+
+        public function getStatusCode(): int
+        {
+            return $this->status;
+        }
+
+        public function getData(bool $assoc = false): array
+        {
+            return $this->data;
+        }
+    }
+
     class RequestStack
     {
         public function getCurrentRequest(): mixed
@@ -37,12 +60,25 @@ namespace Symfony\Component\HttpFoundation {
 }
 
 namespace Symfony\Component\HttpKernel\Exception {
-    class BadRequestHttpException extends \RuntimeException
+    interface HttpExceptionInterface
     {
+        public function getStatusCode(): int;
     }
 
-    class AccessDeniedHttpException extends \RuntimeException
+    class BadRequestHttpException extends \RuntimeException implements HttpExceptionInterface
     {
+        public function getStatusCode(): int
+        {
+            return 400;
+        }
+    }
+
+    class AccessDeniedHttpException extends \RuntimeException implements HttpExceptionInterface
+    {
+        public function getStatusCode(): int
+        {
+            return 403;
+        }
     }
 }
 
@@ -92,13 +128,20 @@ namespace ControleOnline\Entity {
         public const EMPLOYEE_LINK = ['employee'];
         public const MANAGER_LINK = ['owner', 'director', 'manager'];
 
-        public function __construct(private ?People $company = null)
-        {
+        public function __construct(
+            private ?People $company = null,
+            private bool $enabled = true
+        ) {
         }
 
         public function getCompany(): ?People
         {
             return $this->company;
+        }
+
+        public function getEnabled(): bool
+        {
+            return $this->enabled;
         }
     }
 
@@ -192,8 +235,10 @@ namespace ControleOnline\Entity {
     {
         public function __construct(
             private int $id = 0,
-            private LinkCollection $link = new LinkCollection()
+            private ?LinkCollection $link = null,
+            private int $enabled = 1
         ) {
+            $this->link ??= new LinkCollection();
         }
 
         public function getId(): int
@@ -253,7 +298,7 @@ namespace ControleOnline\Entity {
 
         public function getEnabled(): int
         {
-            return 1;
+            return $this->enabled;
         }
 
         public function getPeopleType(): string
@@ -317,4 +362,5 @@ namespace ControleOnline\Service {
 
 namespace {
     require_once __DIR__ . '/../src/Service/UserService.php';
+    require_once __DIR__ . '/../src/Controller/DeleteUserAction.php';
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -90,6 +90,7 @@ namespace ControleOnline\Entity {
     class PeopleLink
     {
         public const EMPLOYEE_LINK = ['employee'];
+        public const MANAGER_LINK = ['owner', 'director', 'manager'];
 
         public function __construct(private ?People $company = null)
         {
@@ -278,6 +279,8 @@ namespace ControleOnline\Entity {
 }
 
 namespace ControleOnline\Service {
+    use ControleOnline\Entity\PeopleLink;
+
     class FileService
     {
         public function getFileUrl($people): string
@@ -288,7 +291,7 @@ namespace ControleOnline\Service {
 
     class PeopleRoleService
     {
-        public function __construct(private array $companies = [])
+        public function __construct(private array $companiesByRoleType = [])
         {
         }
 
@@ -299,7 +302,15 @@ namespace ControleOnline\Service {
 
         public function getAccessibleCompaniesForPeople($people, $companyType = null): array
         {
-            return $this->companies;
+            if ($companyType === PeopleLink::MANAGER_LINK) {
+                return $this->companiesByRoleType['manager'] ?? [];
+            }
+
+            if ($companyType === PeopleLink::EMPLOYEE_LINK) {
+                return $this->companiesByRoleType['employee'] ?? [];
+            }
+
+            return $this->companiesByRoleType['default'] ?? [];
         }
     }
 }


### PR DESCRIPTION
## Summary
- keep `DELETE /users/{id}` on the same guarded `UserService` path used by the other sensitive user-management operations
- ignore disabled `people_link` rows and disabled companies when deciding whether a person can be read or managed through `UserService`
- extend the focused PHPUnit harness with coverage for disabled-link authorization and the new delete-action wiring

## Issue
- relates to `ControleOnline/app-community#95`

## Validation
- GitHub Actions `Pull Request Checks` succeeded on head `2b5fdbcad77c7160d28b8416c9bfe6309652f447` (run `#36`)
- local PHP runtime remains unavailable in this workspace, so the executable evidence for this round stays published in the branch workflow

## Notes
- this repository does not expose a `dev` branch, so the review branch targets `master` to keep the diff isolated
- the previous draft PR `#4` was closed only because the connector still fails the `mark ready for review` mutation with a GraphQL schema error on `htmlUrl`; the branch and diff are the same review trail